### PR TITLE
Support vcs.CommitsOptions.Path.

### DIFF
--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -547,6 +547,7 @@ type RepoListCommitsOptions struct {
 	Head        string `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty"`
 	Base        string `protobuf:"bytes,2,opt,name=base,proto3" json:"base,omitempty"`
 	ListOptions `protobuf:"bytes,3,opt,name=list_options,embedded=list_options" json:"list_options"`
+	Path        string `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
 }
 
 func (m *RepoListCommitsOptions) Reset()         { *m = RepoListCommitsOptions{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -343,6 +343,7 @@ message RepoListCommitsOptions {
 	string head = 1;
 	string base = 2;
 	ListOptions list_options = 3 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	string path = 4;
 }
 
 message CommitList {


### PR DESCRIPTION
Exposes functionality of sourcegraph/go-vcs#50.