### PR TITLE
Make go generate directives work on more setups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ _TODO: Make it work with latest, confirm if there are any issues._
    go install ./...
    ```
 
-3. **Install [gen-mocks](https://sourcegraph.com/sourcegraph/gen-mocks)** by running:
+3. **Install `grpc`** by following steps at https://github.com/grpc/grpc-go#installation.
+
+4. **Install [gen-mocks](https://sourcegraph.com/sourcegraph/gen-mocks)** by running:
 
    ```
    go get -u sourcegraph.com/sourcegraph/gen-mocks
    ```
 
-4. **Install `gopathexec`**:
+5. **Install `gopathexec`**:
 
    ```
    go get -u github.com/shurcooL/gopathexec

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _TODO: Make it work with latest, confirm if there are any issues._
 5. **Install `gopathexec`**:
 
    ```
-   go get -u github.com/shurcooL/gopathexec
+   go get -u sourcegraph.com/sourcegraph/gopathexec
    ```
 
 ### Regenerating Go code after changing `sourcegraph.proto`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ interfaces.
 You need to install and run the protobuf compiler before you can
 regenerate Go code after you change the `sourcegraph.proto` file.
 
+If you run into errors while compiling protobufs, try again with these older versions that are known to work:
+
+-  `protoc` - version `3.0.0-alpha-2`.
+-  `protoc-gen-gogo` - commit `0d32fa3409f705a45020a232768fb9b121f377e9`.
+
+_TODO: Make it work with latest, confirm if there are any issues._
+
 1. **Install protoc**, the protobuf compiler. Find more details at the [protobuf README](https://github.com/google/protobuf)).
 
    ```
@@ -50,22 +57,6 @@ regenerate Go code after you change the `sourcegraph.proto` file.
    ```
    go get -u github.com/shurcooL/gopathexec
    ```
-
-#### OS X-specific
-
-```
-brew install gnu-sed --with-default-names
-```
-
-#### Unconfirmed
-
-_TODO: Make it work with latest, confirm if there are any issues._
-
-If you run into errors while compiling protobufs, try again with these older versions that are known to work:
-
--  `protoc` - version `3.0.0-alpha-2`.
--  `protoc-gen-gogo` - commit `0d32fa3409f705a45020a232768fb9b121f377e9`.
-
 
 ### Regenerating Go code after changing `sourcegraph.proto`
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ regenerate Go code after you change the `sourcegraph.proto` file.
    ./autogen.sh
    ./configure --enable-static && make && sudo make install
    ```
- 
+
    Then make sure the `protoc` binary is in your `$PATH`.
-1. **Install [gogo/protobuf](https://github.com/gogo/protobuf)**, on the `proto3` branch.
+
+2. **Install [gogo/protobuf](https://github.com/gogo/protobuf)**, on the `proto3` branch.
 
    ```
    go get -u -a github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
@@ -37,11 +38,34 @@ regenerate Go code after you change the `sourcegraph.proto` file.
    git checkout proto3
    go install ./...
    ```
-1. **Install [gen-mocks](https://sourcegraph.com/sourcegraph/gen-mocks)** by running:
+
+3. **Install [gen-mocks](https://sourcegraph.com/sourcegraph/gen-mocks)** by running:
 
    ```
    go get -u sourcegraph.com/sourcegraph/gen-mocks
    ```
+
+4. **Install `gopathexec`**:
+
+   ```
+   go get -u github.com/shurcooL/gopathexec
+   ```
+
+#### OS X-specific
+
+```
+brew install gnu-sed --with-default-names
+```
+
+#### Unconfirmed
+
+_TODO: Make it work with latest, confirm if there are any issues._
+
+If you run into errors while compiling protobufs, try again with these older versions that are known to work:
+
+-  `protoc` - version `3.0.0-alpha-2`.
+-  `protoc-gen-gogo` - commit `0d32fa3409f705a45020a232768fb9b121f377e9`.
+
 
 ### Regenerating Go code after changing `sourcegraph.proto`
 

--- a/sourcegraph/gen.go
+++ b/sourcegraph/gen.go
@@ -7,7 +7,7 @@ package sourcegraph
 // The pbtypes package selector is emitted as pbtypes1 when more than
 // one pbtypes type is used. Fix this up so that goimports works.
 //
-//go:generate sed -i "s#pbtypes1#pbtypes#g" mock/sourcegraph.pb_mock.go
+//go:generate go run gen/goreplace.go -from "pbtypes1" -to "pbtypes" mock/sourcegraph.pb_mock.go
 
 //go:generate goimports -w mock/sourcegraph.pb_mock.go
 

--- a/sourcegraph/gen.go
+++ b/sourcegraph/gen.go
@@ -1,6 +1,6 @@
 package sourcegraph
 
-//go:generate protoc -I../../../../ -I../../../../github.com/gogo/protobuf/protobuf -I../../../../github.com/gengo/grpc-gateway/third_party/googleapis -I. --gogo_out=plugins=grpc:. sourcegraph.proto
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I$GOPATH/src/github.com/gengo/grpc-gateway/third_party/googleapis -I. --gogo_out=plugins=grpc:. sourcegraph.proto
 
 //go:generate gen-mocks -w -i=.+(Server|Client|Service)$ -o mock -outpkg mock -name_prefix= -no_pass_args=opts
 

--- a/sourcegraph/gen/goreplace.go
+++ b/sourcegraph/gen/goreplace.go
@@ -1,0 +1,49 @@
+// +build ignore
+
+// Command goreplace replaces all instances of "from" string with "to" string in specified files.
+// Like basic string replacement functionality of sed, but works on OS X, Linux and Windows.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	var fromFlag = flag.String("from", "", "source string to replace")
+	var toFlag = flag.String("to", "", "string to replace with")
+	flag.Parse()
+
+	files := flag.Args()
+	if len(files) == 0 {
+		log.Fatalln("no files to process")
+	}
+
+	for _, path := range files {
+		fmt.Fprintln(os.Stderr, "#", path)
+		err := processFile(path, *fromFlag, *toFlag)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}
+
+func processFile(path, from, to string) error {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	b = bytes.Replace(b, []byte(from), []byte(to), -1)
+
+	err = ioutil.WriteFile(path, b, 0x0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add support for running go generate successfully on OS X.

Add support for running go generate with multiple GOPATH workspaces.