### PR TITLE
Add url omitempty option for RepoListCommitsOptions fields.

### DIFF
--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -733,10 +733,10 @@ func (m *ReposListCommitsOp) String() string { return proto.CompactTextString(m)
 func (*ReposListCommitsOp) ProtoMessage()    {}
 
 type RepoListCommitsOptions struct {
-	Head        string `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty"`
-	Base        string `protobuf:"bytes,2,opt,name=base,proto3" json:"base,omitempty"`
+	Head        string `protobuf:"bytes,1,opt,name=head,proto3" json:"head,omitempty" url:",omitempty"`
+	Base        string `protobuf:"bytes,2,opt,name=base,proto3" json:"base,omitempty" url:",omitempty"`
 	ListOptions `protobuf:"bytes,3,opt,name=list_options,embedded=list_options" json:"list_options"`
-	Path        string `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
+	Path        string `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty" url:",omitempty"`
 }
 
 func (m *RepoListCommitsOptions) Reset()         { *m = RepoListCommitsOptions{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -577,10 +577,10 @@ message ReposListCommitsOp {
 }
 
 message RepoListCommitsOptions {
-	string head = 1;
-	string base = 2;
+	string head = 1 [(gogoproto.moretags) = "url:\",omitempty\""];
+	string base = 2 [(gogoproto.moretags) = "url:\",omitempty\""];
 	ListOptions list_options = 3 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-	string path = 4;
+	string path = 4 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
 message CommitList {
@@ -2548,7 +2548,7 @@ message ServerConfig {
 	// IsFederationRoot is whether this server is itself a federation
 	// root. If true, then FederationRootURL is empty.
 	bool is_federation_root = 6;
-}	
+}
 
 // A RegisteredClient is a registered API client.
 //


### PR DESCRIPTION
This will allow cleaner urls when most `RepoListCommitsOptions` options are unchanged from their defaults.