### PR TITLE
sourcegraph: added gRPC method to list committers on a repo

### DIFF
--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -92,18 +92,19 @@ func (s *RepoStatusesServer) Create(v0 context.Context, v1 *sourcegraph.RepoStat
 var _ sourcegraph.RepoStatusesServer = (*RepoStatusesServer)(nil)
 
 type ReposClient struct {
-	Get_          func(ctx context.Context, in *sourcegraph.RepoSpec) (*sourcegraph.Repo, error)
-	List_         func(ctx context.Context, in *sourcegraph.RepoListOptions) (*sourcegraph.RepoList, error)
-	Create_       func(ctx context.Context, in *sourcegraph.ReposCreateOp) (*sourcegraph.Repo, error)
-	Delete_       func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	GetReadme_    func(ctx context.Context, in *sourcegraph.RepoRevSpec) (*sourcegraph.Readme, error)
-	Enable_       func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	Disable_      func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	GetConfig_    func(ctx context.Context, in *sourcegraph.RepoSpec) (*sourcegraph.RepoConfig, error)
-	GetCommit_    func(ctx context.Context, in *sourcegraph.RepoRevSpec) (*vcs.Commit, error)
-	ListCommits_  func(ctx context.Context, in *sourcegraph.ReposListCommitsOp) (*sourcegraph.CommitList, error)
-	ListBranches_ func(ctx context.Context, in *sourcegraph.ReposListBranchesOp) (*sourcegraph.BranchList, error)
-	ListTags_     func(ctx context.Context, in *sourcegraph.ReposListTagsOp) (*sourcegraph.TagList, error)
+	Get_            func(ctx context.Context, in *sourcegraph.RepoSpec) (*sourcegraph.Repo, error)
+	List_           func(ctx context.Context, in *sourcegraph.RepoListOptions) (*sourcegraph.RepoList, error)
+	Create_         func(ctx context.Context, in *sourcegraph.ReposCreateOp) (*sourcegraph.Repo, error)
+	Delete_         func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	GetReadme_      func(ctx context.Context, in *sourcegraph.RepoRevSpec) (*sourcegraph.Readme, error)
+	Enable_         func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	Disable_        func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	GetConfig_      func(ctx context.Context, in *sourcegraph.RepoSpec) (*sourcegraph.RepoConfig, error)
+	GetCommit_      func(ctx context.Context, in *sourcegraph.RepoRevSpec) (*vcs.Commit, error)
+	ListCommits_    func(ctx context.Context, in *sourcegraph.ReposListCommitsOp) (*sourcegraph.CommitList, error)
+	ListBranches_   func(ctx context.Context, in *sourcegraph.ReposListBranchesOp) (*sourcegraph.BranchList, error)
+	ListTags_       func(ctx context.Context, in *sourcegraph.ReposListTagsOp) (*sourcegraph.TagList, error)
+	ListCommitters_ func(ctx context.Context, in *sourcegraph.ReposListCommittersOp) (*sourcegraph.CommitterList, error)
 }
 
 func (s *ReposClient) Get(ctx context.Context, in *sourcegraph.RepoSpec, opts ...grpc.CallOption) (*sourcegraph.Repo, error) {
@@ -154,21 +155,26 @@ func (s *ReposClient) ListTags(ctx context.Context, in *sourcegraph.ReposListTag
 	return s.ListTags_(ctx, in)
 }
 
+func (s *ReposClient) ListCommitters(ctx context.Context, in *sourcegraph.ReposListCommittersOp, opts ...grpc.CallOption) (*sourcegraph.CommitterList, error) {
+	return s.ListCommitters_(ctx, in)
+}
+
 var _ sourcegraph.ReposClient = (*ReposClient)(nil)
 
 type ReposServer struct {
-	Get_          func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*sourcegraph.Repo, error)
-	List_         func(v0 context.Context, v1 *sourcegraph.RepoListOptions) (*sourcegraph.RepoList, error)
-	Create_       func(v0 context.Context, v1 *sourcegraph.ReposCreateOp) (*sourcegraph.Repo, error)
-	Delete_       func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	GetReadme_    func(v0 context.Context, v1 *sourcegraph.RepoRevSpec) (*sourcegraph.Readme, error)
-	Enable_       func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	Disable_      func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
-	GetConfig_    func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*sourcegraph.RepoConfig, error)
-	GetCommit_    func(v0 context.Context, v1 *sourcegraph.RepoRevSpec) (*vcs.Commit, error)
-	ListCommits_  func(v0 context.Context, v1 *sourcegraph.ReposListCommitsOp) (*sourcegraph.CommitList, error)
-	ListBranches_ func(v0 context.Context, v1 *sourcegraph.ReposListBranchesOp) (*sourcegraph.BranchList, error)
-	ListTags_     func(v0 context.Context, v1 *sourcegraph.ReposListTagsOp) (*sourcegraph.TagList, error)
+	Get_            func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*sourcegraph.Repo, error)
+	List_           func(v0 context.Context, v1 *sourcegraph.RepoListOptions) (*sourcegraph.RepoList, error)
+	Create_         func(v0 context.Context, v1 *sourcegraph.ReposCreateOp) (*sourcegraph.Repo, error)
+	Delete_         func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	GetReadme_      func(v0 context.Context, v1 *sourcegraph.RepoRevSpec) (*sourcegraph.Readme, error)
+	Enable_         func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	Disable_        func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	GetConfig_      func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*sourcegraph.RepoConfig, error)
+	GetCommit_      func(v0 context.Context, v1 *sourcegraph.RepoRevSpec) (*vcs.Commit, error)
+	ListCommits_    func(v0 context.Context, v1 *sourcegraph.ReposListCommitsOp) (*sourcegraph.CommitList, error)
+	ListBranches_   func(v0 context.Context, v1 *sourcegraph.ReposListBranchesOp) (*sourcegraph.BranchList, error)
+	ListTags_       func(v0 context.Context, v1 *sourcegraph.ReposListTagsOp) (*sourcegraph.TagList, error)
+	ListCommitters_ func(v0 context.Context, v1 *sourcegraph.ReposListCommittersOp) (*sourcegraph.CommitterList, error)
 }
 
 func (s *ReposServer) Get(v0 context.Context, v1 *sourcegraph.RepoSpec) (*sourcegraph.Repo, error) {
@@ -217,6 +223,10 @@ func (s *ReposServer) ListBranches(v0 context.Context, v1 *sourcegraph.ReposList
 
 func (s *ReposServer) ListTags(v0 context.Context, v1 *sourcegraph.ReposListTagsOp) (*sourcegraph.TagList, error) {
 	return s.ListTags_(v0, v1)
+}
+
+func (s *ReposServer) ListCommitters(v0 context.Context, v1 *sourcegraph.ReposListCommittersOp) (*sourcegraph.CommitterList, error) {
+	return s.ListCommitters_(v0, v1)
 }
 
 var _ sourcegraph.ReposServer = (*ReposServer)(nil)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -41,6 +41,9 @@ It has these top-level messages:
 	RepoListBranchesOptions
 	BranchList
 	ReposListTagsOp
+	ReposListCommittersOp
+	RepoListCommittersOptions
+	CommitterList
 	ChangesetCreateOp
 	ChangesetCreateReviewOp
 	ChangesetListReviewsOp
@@ -786,6 +789,33 @@ type ReposListTagsOp struct {
 func (m *ReposListTagsOp) Reset()         { *m = ReposListTagsOp{} }
 func (m *ReposListTagsOp) String() string { return proto.CompactTextString(m) }
 func (*ReposListTagsOp) ProtoMessage()    {}
+
+type ReposListCommittersOp struct {
+	Repo RepoSpec                   `protobuf:"bytes,1,opt,name=repo" json:"repo"`
+	Opt  *RepoListCommittersOptions `protobuf:"bytes,2,opt,name=opt" json:"opt,omitempty"`
+}
+
+func (m *ReposListCommittersOp) Reset()         { *m = ReposListCommittersOp{} }
+func (m *ReposListCommittersOp) String() string { return proto.CompactTextString(m) }
+func (*ReposListCommittersOp) ProtoMessage()    {}
+
+type RepoListCommittersOptions struct {
+	Revision    string `protobuf:"bytes,3,opt,name=revision,proto3" json:"revision,omitempty"`
+	ListOptions `protobuf:"bytes,4,opt,name=list_options,embedded=list_options" json:"list_options"`
+}
+
+func (m *RepoListCommittersOptions) Reset()         { *m = RepoListCommittersOptions{} }
+func (m *RepoListCommittersOptions) String() string { return proto.CompactTextString(m) }
+func (*RepoListCommittersOptions) ProtoMessage()    {}
+
+type CommitterList struct {
+	Committers   []*vcs.Committer `protobuf:"bytes,1,rep,name=committers" json:"committers,omitempty"`
+	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+}
+
+func (m *CommitterList) Reset()         { *m = CommitterList{} }
+func (m *CommitterList) String() string { return proto.CompactTextString(m) }
+func (*CommitterList) ProtoMessage()    {}
 
 type ChangesetCreateOp struct {
 	Repo      RepoSpec   `protobuf:"bytes,1,opt,name=repo" json:"repo"`
@@ -3095,6 +3125,9 @@ type ReposClient interface {
 	ListCommits(ctx context.Context, in *ReposListCommitsOp, opts ...grpc.CallOption) (*CommitList, error)
 	ListBranches(ctx context.Context, in *ReposListBranchesOp, opts ...grpc.CallOption) (*BranchList, error)
 	ListTags(ctx context.Context, in *ReposListTagsOp, opts ...grpc.CallOption) (*TagList, error)
+	// ListCommitters returns the list of authors who have contributed
+	// to the main branch of the repo.
+	ListCommitters(ctx context.Context, in *ReposListCommittersOp, opts ...grpc.CallOption) (*CommitterList, error)
 }
 
 type reposClient struct {
@@ -3213,6 +3246,15 @@ func (c *reposClient) ListTags(ctx context.Context, in *ReposListTagsOp, opts ..
 	return out, nil
 }
 
+func (c *reposClient) ListCommitters(ctx context.Context, in *ReposListCommittersOp, opts ...grpc.CallOption) (*CommitterList, error) {
+	out := new(CommitterList)
+	err := grpc.Invoke(ctx, "/sourcegraph.Repos/ListCommitters", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Repos service
 
 type ReposServer interface {
@@ -3244,6 +3286,9 @@ type ReposServer interface {
 	ListCommits(context.Context, *ReposListCommitsOp) (*CommitList, error)
 	ListBranches(context.Context, *ReposListBranchesOp) (*BranchList, error)
 	ListTags(context.Context, *ReposListTagsOp) (*TagList, error)
+	// ListCommitters returns the list of authors who have contributed
+	// to the main branch of the repo.
+	ListCommitters(context.Context, *ReposListCommittersOp) (*CommitterList, error)
 }
 
 func RegisterReposServer(s *grpc.Server, srv ReposServer) {
@@ -3394,6 +3439,18 @@ func _Repos_ListTags_Handler(srv interface{}, ctx context.Context, codec grpc.Co
 	return out, nil
 }
 
+func _Repos_ListCommitters_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(ReposListCommittersOp)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ReposServer).ListCommitters(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _Repos_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sourcegraph.Repos",
 	HandlerType: (*ReposServer)(nil),
@@ -3445,6 +3502,10 @@ var _Repos_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListTags",
 			Handler:    _Repos_ListTags_Handler,
+		},
+		{
+			MethodName: "ListCommitters",
+			Handler:    _Repos_ListCommitters_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -800,8 +800,8 @@ func (m *ReposListCommittersOp) String() string { return proto.CompactTextString
 func (*ReposListCommittersOp) ProtoMessage()    {}
 
 type RepoListCommittersOptions struct {
-	Revision    string `protobuf:"bytes,3,opt,name=revision,proto3" json:"revision,omitempty"`
-	ListOptions `protobuf:"bytes,4,opt,name=list_options,embedded=list_options" json:"list_options"`
+	Rev         string `protobuf:"bytes,1,opt,name=rev,proto3" json:"rev,omitempty"`
+	ListOptions `protobuf:"bytes,2,opt,name=list_options,embedded=list_options" json:"list_options"`
 }
 
 func (m *RepoListCommittersOptions) Reset()         { *m = RepoListCommittersOptions{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -618,8 +618,8 @@ message ReposListCommittersOp {
 }
 
 message RepoListCommittersOptions {
-	string revision = 3;
-	ListOptions list_options = 4 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	string rev = 1;
+	ListOptions list_options = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message CommitterList {

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -519,6 +519,10 @@ service Repos {
 	rpc ListCommits(ReposListCommitsOp) returns (CommitList);
 	rpc ListBranches(ReposListBranchesOp) returns (BranchList);
 	rpc ListTags(ReposListTagsOp) returns (TagList);
+
+	// ListCommitters returns the list of authors who have contributed
+	// to the main branch of the repo.
+	rpc ListCommitters(ReposListCommittersOp) returns (CommitterList);
 }
 
 service Changesets {
@@ -606,6 +610,21 @@ message BranchList {
 message ReposListTagsOp {
 	RepoSpec repo = 1 [(gogoproto.nullable) = false];
 	RepoListTagsOptions opt = 2;
+}
+
+message ReposListCommittersOp {
+	RepoSpec repo = 1 [(gogoproto.nullable) = false];
+	RepoListCommittersOptions opt = 2;
+}
+
+message RepoListCommittersOptions {
+	string revision = 3;
+	ListOptions list_options = 4 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+message CommitterList {
+	repeated vcs.Committer committers = 1;
+	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message ChangesetCreateOp {


### PR DESCRIPTION
This change adds a new gRPC method to the Repos service: ListCommitters(), which returns the list of committers in the specified repo, along with their email ids and total number of commits on the specified revision.