### PR TITLE
Add support for creating and refreshing private repos.

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -1603,7 +1603,7 @@ func (s *CachedMetaClient) Config(ctx context.Context, in *pbtypes.Void, opts ..
 
 type CachedMirrorReposServer struct{ MirrorReposServer }
 
-func (s *CachedMirrorReposServer) RefreshVCS(ctx context.Context, in *RepoSpec) (*pbtypes.Void, error) {
+func (s *CachedMirrorReposServer) RefreshVCS(ctx context.Context, in *MirrorReposRefreshVCSOp) (*pbtypes.Void, error) {
 	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
 	result, err := s.MirrorReposServer.RefreshVCS(ctx, in)
 	if !cc.IsZero() {
@@ -1619,7 +1619,7 @@ type CachedMirrorReposClient struct {
 	Cache *grpccache.Cache
 }
 
-func (s *CachedMirrorReposClient) RefreshVCS(ctx context.Context, in *RepoSpec, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+func (s *CachedMirrorReposClient) RefreshVCS(ctx context.Context, in *MirrorReposRefreshVCSOp, opts ...grpc.CallOption) (*pbtypes.Void, error) {
 	if s.Cache != nil {
 		var cachedResult pbtypes.Void
 		cached, err := s.Cache.Get(ctx, "MirrorRepos.RefreshVCS", in, &cachedResult)

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -302,20 +302,20 @@ func (s *ChangesetsServer) ListEvents(v0 context.Context, v1 *sourcegraph.Change
 var _ sourcegraph.ChangesetsServer = (*ChangesetsServer)(nil)
 
 type MirrorReposClient struct {
-	RefreshVCS_ func(ctx context.Context, in *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	RefreshVCS_ func(ctx context.Context, in *sourcegraph.MirrorReposRefreshVCSOp) (*pbtypes.Void, error)
 }
 
-func (s *MirrorReposClient) RefreshVCS(ctx context.Context, in *sourcegraph.RepoSpec, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+func (s *MirrorReposClient) RefreshVCS(ctx context.Context, in *sourcegraph.MirrorReposRefreshVCSOp, opts ...grpc.CallOption) (*pbtypes.Void, error) {
 	return s.RefreshVCS_(ctx, in)
 }
 
 var _ sourcegraph.MirrorReposClient = (*MirrorReposClient)(nil)
 
 type MirrorReposServer struct {
-	RefreshVCS_ func(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error)
+	RefreshVCS_ func(v0 context.Context, v1 *sourcegraph.MirrorReposRefreshVCSOp) (*pbtypes.Void, error)
 }
 
-func (s *MirrorReposServer) RefreshVCS(v0 context.Context, v1 *sourcegraph.RepoSpec) (*pbtypes.Void, error) {
+func (s *MirrorReposServer) RefreshVCS(v0 context.Context, v1 *sourcegraph.MirrorReposRefreshVCSOp) (*pbtypes.Void, error) {
 	return s.RefreshVCS_(v0, v1)
 }
 

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -48,6 +48,8 @@ It has these top-level messages:
 	ChangesetUpdateOp
 	RepoListTagsOptions
 	TagList
+	MirrorReposRefreshVCSOp
+	VCSCredentials
 	MirroredRepoSSHKeysCreateOp
 	SSHPrivateKey
 	Build
@@ -713,6 +715,8 @@ type ReposCreateOp struct {
 	// periodically updated to track their upstream (which is
 	// specified using the CloneURL field of this message).
 	Mirror bool `protobuf:"varint,4,opt,name=mirror,proto3" json:"mirror,omitempty"`
+	// Private is whether this repository is private.
+	Private bool `protobuf:"varint,5,opt,name=private,proto3" json:"private,omitempty"`
 }
 
 func (m *ReposCreateOp) Reset()         { *m = ReposCreateOp{} }
@@ -864,6 +868,25 @@ type TagList struct {
 func (m *TagList) Reset()         { *m = TagList{} }
 func (m *TagList) String() string { return proto.CompactTextString(m) }
 func (*TagList) ProtoMessage()    {}
+
+type MirrorReposRefreshVCSOp struct {
+	Repo        RepoSpec        `protobuf:"bytes,1,opt,name=repo" json:"repo"`
+	Credentials *VCSCredentials `protobuf:"bytes,2,opt,name=credentials" json:"credentials,omitempty"`
+}
+
+func (m *MirrorReposRefreshVCSOp) Reset()         { *m = MirrorReposRefreshVCSOp{} }
+func (m *MirrorReposRefreshVCSOp) String() string { return proto.CompactTextString(m) }
+func (*MirrorReposRefreshVCSOp) ProtoMessage()    {}
+
+// VCSCredentials for authentication during communication with VCS remotes.
+type VCSCredentials struct {
+	// Pass is the password provided to the VCS.
+	Pass string `protobuf:"bytes,1,opt,name=pass,proto3" json:"pass"`
+}
+
+func (m *VCSCredentials) Reset()         { *m = VCSCredentials{} }
+func (m *VCSCredentials) String() string { return proto.CompactTextString(m) }
+func (*VCSCredentials) ProtoMessage()    {}
 
 type MirroredRepoSSHKeysCreateOp struct {
 	Repo RepoSpec      `protobuf:"bytes,1,opt,name=repo" json:"repo"`
@@ -3693,7 +3716,7 @@ var _Changesets_serviceDesc = grpc.ServiceDesc{
 
 type MirrorReposClient interface {
 	// Refresh fetches the newest VCS data from the repo's origin.
-	RefreshVCS(ctx context.Context, in *RepoSpec, opts ...grpc.CallOption) (*pbtypes1.Void, error)
+	RefreshVCS(ctx context.Context, in *MirrorReposRefreshVCSOp, opts ...grpc.CallOption) (*pbtypes1.Void, error)
 }
 
 type mirrorReposClient struct {
@@ -3704,7 +3727,7 @@ func NewMirrorReposClient(cc *grpc.ClientConn) MirrorReposClient {
 	return &mirrorReposClient{cc}
 }
 
-func (c *mirrorReposClient) RefreshVCS(ctx context.Context, in *RepoSpec, opts ...grpc.CallOption) (*pbtypes1.Void, error) {
+func (c *mirrorReposClient) RefreshVCS(ctx context.Context, in *MirrorReposRefreshVCSOp, opts ...grpc.CallOption) (*pbtypes1.Void, error) {
 	out := new(pbtypes1.Void)
 	err := grpc.Invoke(ctx, "/sourcegraph.MirrorRepos/RefreshVCS", in, out, c.cc, opts...)
 	if err != nil {
@@ -3717,7 +3740,7 @@ func (c *mirrorReposClient) RefreshVCS(ctx context.Context, in *RepoSpec, opts .
 
 type MirrorReposServer interface {
 	// Refresh fetches the newest VCS data from the repo's origin.
-	RefreshVCS(context.Context, *RepoSpec) (*pbtypes1.Void, error)
+	RefreshVCS(context.Context, *MirrorReposRefreshVCSOp) (*pbtypes1.Void, error)
 }
 
 func RegisterMirrorReposServer(s *grpc.Server, srv MirrorReposServer) {
@@ -3725,7 +3748,7 @@ func RegisterMirrorReposServer(s *grpc.Server, srv MirrorReposServer) {
 }
 
 func _MirrorRepos_RefreshVCS_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
-	in := new(RepoSpec)
+	in := new(MirrorReposRefreshVCSOp)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -566,6 +566,9 @@ message ReposCreateOp {
 	// periodically updated to track their upstream (which is
 	// specified using the CloneURL field of this message).
 	bool mirror = 4;
+
+	// Private is whether this repository is private.
+	bool private = 5;
 }
 
 message ReposListCommitsOp {
@@ -665,11 +668,22 @@ message TagList {
 	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+message MirrorReposRefreshVCSOp {
+	RepoSpec repo = 1 [(gogoproto.nullable) = false];
+	VCSCredentials credentials = 2;
+}
+
+// VCSCredentials for authentication during communication with VCS remotes.
+message VCSCredentials {
+	// Pass is the password provided to the VCS.
+	string pass = 1 [(gogoproto.nullable) = false];
+}
+
 // MirrorRepos handles operations related to maintaining mirrors on
 // Sourcegraph of repositories hosted elsewhere.
 service MirrorRepos {
 	// Refresh fetches the newest VCS data from the repo's origin.
-	rpc RefreshVCS(RepoSpec) returns (pbtypes.Void) {
+	rpc RefreshVCS(MirrorReposRefreshVCSOp) returns (pbtypes.Void) {
 		option (google.api.http) = {
 			put: "/mirror_repos"
 		};


### PR DESCRIPTION
Add `Private` field to `ReposCreateOp`.

Use `MirrorReposRefreshVCSOp` for `RefreshVCS`, which includes `VCSCredentials`.