### PR TITLE
Incorporate updates to the google.golang.org/grpc package

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ _TODO: Make it work with latest, confirm if there are any issues._
 6. **Install `grpccache-gen`**:
 
    ```
-   go get -u sourcegraph.com/sqs/grpccache/grpccache-gen
+   go get -u sourcegraph.com/sourcegraph/grpccache/grpccache-gen
    ```
 
 ### Regenerating Go code after changing `sourcegraph.proto`

--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"sourcegraph.com/sourcegraph/go-vcs/vcs"
+	"sourcegraph.com/sourcegraph/grpccache"
 	"sourcegraph.com/sourcegraph/srclib/unit"
-	"sourcegraph.com/sqs/grpccache"
 	"sourcegraph.com/sqs/pbtypes"
 )
 

--- a/sourcegraph/client.go
+++ b/sourcegraph/client.go
@@ -2,7 +2,7 @@ package sourcegraph
 
 import (
 	"google.golang.org/grpc"
-	"sourcegraph.com/sqs/grpccache"
+	"sourcegraph.com/sourcegraph/grpccache"
 )
 
 // A Client communicates with the Sourcegraph API. All communication

--- a/sourcegraph/conn_pool.go
+++ b/sourcegraph/conn_pool.go
@@ -41,7 +41,7 @@ func pooledGRPCDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, e
 	if conns == nil {
 		conns = map[string]*grpc.ClientConn{}
 	}
-	if conn := conns[target]; conn != nil {
+	if conn := conns[target]; conn != nil && conn.State() != grpc.Shutdown {
 		connsMu.Unlock()
 		return conn, nil
 	}


### PR DESCRIPTION
Use the ClientConnection.State() method to check if the client
connection is in a shutdown state, and reboot it.

grpc/credentials.TokenSource -> grpc/credentials/oauth.TokenSource