### PR TITLE
Remove grpc connection from pool

### DIFF
--- a/sourcegraph/conn_pool.go
+++ b/sourcegraph/conn_pool.go
@@ -58,3 +58,18 @@ func pooledGRPCDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, e
 
 	return conn, nil
 }
+
+// removeConnFromPool deletes the ClientConnection to the specified target
+// from the connection pool.
+func removeConnFromPool(target string) {
+	// Make sure we are the only goroutine dealing with this target.
+	targetMu := lockTargetMutex(target)
+	defer targetMu.Unlock()
+
+	connsMu.Lock()
+	defer connsMu.Unlock()
+
+	if conns != nil {
+		conns[target] = nil
+	}
+}

--- a/sourcegraph/context.go
+++ b/sourcegraph/context.go
@@ -124,6 +124,15 @@ var NewClientFromContext = func(ctx context.Context) *Client {
 	return c
 }
 
+// RemovePooledGRPCConn removes the pooled grpc.ClientConnection to the gRPC endpoint
+// in the context. The result of calling this function  is that the pooled connection for
+// this endpoint will be reset, so the subsequent call to NewClientFromContext() would have
+// to dial a new gRPC connection to this endpoint.
+var RemovePooledGRPCConn = func(ctx context.Context) {
+	grpcEndpoint := GRPCEndpoint(ctx)
+	removeConnFromPool(grpcEndpoint.Host)
+}
+
 type contextCredentials struct{}
 
 func (contextCredentials) GetRequestMetadata(ctx context.Context) (map[string]string, error) {


### PR DESCRIPTION
Added RemovePooledGRPCConn to reset the gRPC ClientConnection to a target host. This is used by the server to reset the connection to a remote target when the connection goes stale.

This fixes `grpc: client connection is closing` errors when the remote target goes down and comes back up.

Note that this is a temporary fix. The new updates to grpc-go library allow a simpler way to reset the ClientConnection by checking `conn.State() == grpc.Shutdown`. However, the updates also include incompatible API changes in gRPC auth so this is a bridge until the updates are properly merged in.