### PR TITLE
goreplace.go: Fix invalid permissions.

### DIFF
--- a/sourcegraph/gen/goreplace.go
+++ b/sourcegraph/gen/goreplace.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build generate
 
 // Command goreplace replaces all instances of "from" string with "to" string in specified files.
 // Like basic string replacement functionality of sed, but works on OS X, Linux and Windows.
@@ -40,7 +40,7 @@ func processFile(path, from, to string) error {
 
 	b = bytes.Replace(b, []byte(from), []byte(to), -1)
 
-	err = ioutil.WriteFile(path, b, 0x0644)
+	err = ioutil.WriteFile(path, b, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Meant to use octal, not hex.

Use "generate" build tag rather than "ignore" for consistency, and making it easier to fetch dependencies of generator programs (in this case, it doesn't matter since all dependencies are in std lib).