### PR TITLE
User whitelist

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -2141,7 +2141,7 @@ func (s *CachedRegisteredClientsServer) GetCurrent(ctx context.Context, in *pbty
 	return result, err
 }
 
-func (s *CachedRegisteredClientsServer) Create(ctx context.Context, in *RegisteredClientsCreateOp) (*RegisteredClient, error) {
+func (s *CachedRegisteredClientsServer) Create(ctx context.Context, in *RegisteredClient) (*RegisteredClient, error) {
 	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
 	result, err := s.RegisteredClientsServer.Create(ctx, in)
 	if !cc.IsZero() {
@@ -2177,6 +2177,39 @@ func (s *CachedRegisteredClientsServer) Delete(ctx context.Context, in *Register
 func (s *CachedRegisteredClientsServer) List(ctx context.Context, in *RegisteredClientListOptions) (*RegisteredClientList, error) {
 	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
 	result, err := s.RegisteredClientsServer.List(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedRegisteredClientsServer) GetUserPermissions(ctx context.Context, in *UserPermissionsOptions) (*UserPermissions, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.RegisteredClientsServer.GetUserPermissions(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedRegisteredClientsServer) SetUserPermissions(ctx context.Context, in *UserPermissions) (*pbtypes.Void, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.RegisteredClientsServer.SetUserPermissions(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedRegisteredClientsServer) ListUserPermissions(ctx context.Context, in *RegisteredClientSpec) (*UserPermissionsList, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.RegisteredClientsServer.ListUserPermissions(ctx, in)
 	if !cc.IsZero() {
 		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
 			return nil, err
@@ -2242,7 +2275,7 @@ func (s *CachedRegisteredClientsClient) GetCurrent(ctx context.Context, in *pbty
 	return result, nil
 }
 
-func (s *CachedRegisteredClientsClient) Create(ctx context.Context, in *RegisteredClientsCreateOp, opts ...grpc.CallOption) (*RegisteredClient, error) {
+func (s *CachedRegisteredClientsClient) Create(ctx context.Context, in *RegisteredClient, opts ...grpc.CallOption) (*RegisteredClient, error) {
 	if s.Cache != nil {
 		var cachedResult RegisteredClient
 		cached, err := s.Cache.Get(ctx, "RegisteredClients.Create", in, &cachedResult)
@@ -2340,6 +2373,84 @@ func (s *CachedRegisteredClientsClient) List(ctx context.Context, in *Registered
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "RegisteredClients.List", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedRegisteredClientsClient) GetUserPermissions(ctx context.Context, in *UserPermissionsOptions, opts ...grpc.CallOption) (*UserPermissions, error) {
+	if s.Cache != nil {
+		var cachedResult UserPermissions
+		cached, err := s.Cache.Get(ctx, "RegisteredClients.GetUserPermissions", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.RegisteredClientsClient.GetUserPermissions(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "RegisteredClients.GetUserPermissions", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedRegisteredClientsClient) SetUserPermissions(ctx context.Context, in *UserPermissions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	if s.Cache != nil {
+		var cachedResult pbtypes.Void
+		cached, err := s.Cache.Get(ctx, "RegisteredClients.SetUserPermissions", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.RegisteredClientsClient.SetUserPermissions(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "RegisteredClients.SetUserPermissions", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedRegisteredClientsClient) ListUserPermissions(ctx context.Context, in *RegisteredClientSpec, opts ...grpc.CallOption) (*UserPermissionsList, error) {
+	if s.Cache != nil {
+		var cachedResult UserPermissionsList
+		cached, err := s.Cache.Get(ctx, "RegisteredClients.ListUserPermissions", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.RegisteredClientsClient.ListUserPermissions(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "RegisteredClients.ListUserPermissions", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}
@@ -3422,28 +3533,6 @@ func (s *CachedUsersServer) List(ctx context.Context, in *UsersListOptions) (*Us
 	return result, err
 }
 
-func (s *CachedUsersServer) CheckWhitelist(ctx context.Context, in *UserWhitelistOptions) (*pbtypes.Void, error) {
-	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
-	result, err := s.UsersServer.CheckWhitelist(ctx, in)
-	if !cc.IsZero() {
-		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
-			return nil, err
-		}
-	}
-	return result, err
-}
-
-func (s *CachedUsersServer) AddToWhitelist(ctx context.Context, in *UserWhitelistOptions) (*pbtypes.Void, error) {
-	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
-	result, err := s.UsersServer.AddToWhitelist(ctx, in)
-	if !cc.IsZero() {
-		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
-			return nil, err
-		}
-	}
-	return result, err
-}
-
 type CachedUsersClient struct {
 	UsersClient
 	Cache *grpccache.Cache
@@ -3521,58 +3610,6 @@ func (s *CachedUsersClient) List(ctx context.Context, in *UsersListOptions, opts
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "Users.List", in, result, trailer); err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
-}
-
-func (s *CachedUsersClient) CheckWhitelist(ctx context.Context, in *UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
-	if s.Cache != nil {
-		var cachedResult pbtypes.Void
-		cached, err := s.Cache.Get(ctx, "Users.CheckWhitelist", in, &cachedResult)
-		if err != nil {
-			return nil, err
-		}
-		if cached {
-			return &cachedResult, nil
-		}
-	}
-
-	var trailer metadata.MD
-
-	result, err := s.UsersClient.CheckWhitelist(ctx, in, grpc.Trailer(&trailer))
-	if err != nil {
-		return nil, err
-	}
-	if s.Cache != nil {
-		if err := s.Cache.Store(ctx, "Users.CheckWhitelist", in, result, trailer); err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
-}
-
-func (s *CachedUsersClient) AddToWhitelist(ctx context.Context, in *UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
-	if s.Cache != nil {
-		var cachedResult pbtypes.Void
-		cached, err := s.Cache.Get(ctx, "Users.AddToWhitelist", in, &cachedResult)
-		if err != nil {
-			return nil, err
-		}
-		if cached {
-			return &cachedResult, nil
-		}
-	}
-
-	var trailer metadata.MD
-
-	result, err := s.UsersClient.AddToWhitelist(ctx, in, grpc.Trailer(&trailer))
-	if err != nil {
-		return nil, err
-	}
-	if s.Cache != nil {
-		if err := s.Cache.Store(ctx, "Users.AddToWhitelist", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}

--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -2141,7 +2141,7 @@ func (s *CachedRegisteredClientsServer) GetCurrent(ctx context.Context, in *pbty
 	return result, err
 }
 
-func (s *CachedRegisteredClientsServer) Create(ctx context.Context, in *RegisteredClient) (*RegisteredClient, error) {
+func (s *CachedRegisteredClientsServer) Create(ctx context.Context, in *RegisteredClientsCreateOp) (*RegisteredClient, error) {
 	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
 	result, err := s.RegisteredClientsServer.Create(ctx, in)
 	if !cc.IsZero() {
@@ -2242,7 +2242,7 @@ func (s *CachedRegisteredClientsClient) GetCurrent(ctx context.Context, in *pbty
 	return result, nil
 }
 
-func (s *CachedRegisteredClientsClient) Create(ctx context.Context, in *RegisteredClient, opts ...grpc.CallOption) (*RegisteredClient, error) {
+func (s *CachedRegisteredClientsClient) Create(ctx context.Context, in *RegisteredClientsCreateOp, opts ...grpc.CallOption) (*RegisteredClient, error) {
 	if s.Cache != nil {
 		var cachedResult RegisteredClient
 		cached, err := s.Cache.Get(ctx, "RegisteredClients.Create", in, &cachedResult)

--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -3422,6 +3422,28 @@ func (s *CachedUsersServer) List(ctx context.Context, in *UsersListOptions) (*Us
 	return result, err
 }
 
+func (s *CachedUsersServer) CheckWhitelist(ctx context.Context, in *UserWhitelistOptions) (*pbtypes.Void, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.UsersServer.CheckWhitelist(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedUsersServer) AddToWhitelist(ctx context.Context, in *UserWhitelistOptions) (*pbtypes.Void, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.UsersServer.AddToWhitelist(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
 type CachedUsersClient struct {
 	UsersClient
 	Cache *grpccache.Cache
@@ -3499,6 +3521,58 @@ func (s *CachedUsersClient) List(ctx context.Context, in *UsersListOptions, opts
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "Users.List", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedUsersClient) CheckWhitelist(ctx context.Context, in *UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	if s.Cache != nil {
+		var cachedResult pbtypes.Void
+		cached, err := s.Cache.Get(ctx, "Users.CheckWhitelist", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.UsersClient.CheckWhitelist(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Users.CheckWhitelist", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedUsersClient) AddToWhitelist(ctx context.Context, in *UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	if s.Cache != nil {
+		var cachedResult pbtypes.Void
+		cached, err := s.Cache.Get(ctx, "Users.AddToWhitelist", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.UsersClient.AddToWhitelist(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Users.AddToWhitelist", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -662,9 +662,11 @@ func (s *AccountsServer) Update(v0 context.Context, v1 *sourcegraph.User) (*pbty
 var _ sourcegraph.AccountsServer = (*AccountsServer)(nil)
 
 type UsersClient struct {
-	Get_        func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_ func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_       func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	Get_            func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	ListEmails_     func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_           func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	CheckWhitelist_ func(ctx context.Context, in *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
+	AddToWhitelist_ func(ctx context.Context, in *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
 }
 
 func (s *UsersClient) Get(ctx context.Context, in *sourcegraph.UserSpec, opts ...grpc.CallOption) (*sourcegraph.User, error) {
@@ -679,12 +681,22 @@ func (s *UsersClient) List(ctx context.Context, in *sourcegraph.UsersListOptions
 	return s.List_(ctx, in)
 }
 
+func (s *UsersClient) CheckWhitelist(ctx context.Context, in *sourcegraph.UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.CheckWhitelist_(ctx, in)
+}
+
+func (s *UsersClient) AddToWhitelist(ctx context.Context, in *sourcegraph.UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.AddToWhitelist_(ctx, in)
+}
+
 var _ sourcegraph.UsersClient = (*UsersClient)(nil)
 
 type UsersServer struct {
-	Get_        func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_ func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_       func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	Get_            func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	ListEmails_     func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_           func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	CheckWhitelist_ func(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
+	AddToWhitelist_ func(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
 }
 
 func (s *UsersServer) Get(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error) {
@@ -697,6 +709,14 @@ func (s *UsersServer) ListEmails(v0 context.Context, v1 *sourcegraph.UserSpec) (
 
 func (s *UsersServer) List(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error) {
 	return s.List_(v0, v1)
+}
+
+func (s *UsersServer) CheckWhitelist(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error) {
+	return s.CheckWhitelist_(v0, v1)
+}
+
+func (s *UsersServer) AddToWhitelist(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error) {
+	return s.AddToWhitelist_(v0, v1)
 }
 
 var _ sourcegraph.UsersServer = (*UsersServer)(nil)

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -662,11 +662,9 @@ func (s *AccountsServer) Update(v0 context.Context, v1 *sourcegraph.User) (*pbty
 var _ sourcegraph.AccountsServer = (*AccountsServer)(nil)
 
 type UsersClient struct {
-	Get_            func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_     func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_           func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
-	CheckWhitelist_ func(ctx context.Context, in *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
-	AddToWhitelist_ func(ctx context.Context, in *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
+	Get_        func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	ListEmails_ func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_       func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
 }
 
 func (s *UsersClient) Get(ctx context.Context, in *sourcegraph.UserSpec, opts ...grpc.CallOption) (*sourcegraph.User, error) {
@@ -681,22 +679,12 @@ func (s *UsersClient) List(ctx context.Context, in *sourcegraph.UsersListOptions
 	return s.List_(ctx, in)
 }
 
-func (s *UsersClient) CheckWhitelist(ctx context.Context, in *sourcegraph.UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
-	return s.CheckWhitelist_(ctx, in)
-}
-
-func (s *UsersClient) AddToWhitelist(ctx context.Context, in *sourcegraph.UserWhitelistOptions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
-	return s.AddToWhitelist_(ctx, in)
-}
-
 var _ sourcegraph.UsersClient = (*UsersClient)(nil)
 
 type UsersServer struct {
-	Get_            func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_     func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_           func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
-	CheckWhitelist_ func(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
-	AddToWhitelist_ func(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error)
+	Get_        func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	ListEmails_ func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_       func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
 }
 
 func (s *UsersServer) Get(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error) {
@@ -709,14 +697,6 @@ func (s *UsersServer) ListEmails(v0 context.Context, v1 *sourcegraph.UserSpec) (
 
 func (s *UsersServer) List(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error) {
 	return s.List_(v0, v1)
-}
-
-func (s *UsersServer) CheckWhitelist(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error) {
-	return s.CheckWhitelist_(v0, v1)
-}
-
-func (s *UsersServer) AddToWhitelist(v0 context.Context, v1 *sourcegraph.UserWhitelistOptions) (*pbtypes.Void, error) {
-	return s.AddToWhitelist_(v0, v1)
 }
 
 var _ sourcegraph.UsersServer = (*UsersServer)(nil)
@@ -1062,12 +1042,15 @@ func (s *MetaServer) Config(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.
 var _ sourcegraph.MetaServer = (*MetaServer)(nil)
 
 type RegisteredClientsClient struct {
-	Get_        func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
-	GetCurrent_ func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
-	Create_     func(ctx context.Context, in *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error)
-	Update_     func(ctx context.Context, in *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
-	Delete_     func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
-	List_       func(ctx context.Context, in *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
+	Get_                 func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
+	GetCurrent_          func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
+	Create_              func(ctx context.Context, in *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error)
+	Update_              func(ctx context.Context, in *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
+	Delete_              func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
+	List_                func(ctx context.Context, in *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
+	GetUserPermissions_  func(ctx context.Context, in *sourcegraph.UserPermissionsOptions) (*sourcegraph.UserPermissions, error)
+	SetUserPermissions_  func(ctx context.Context, in *sourcegraph.UserPermissions) (*pbtypes.Void, error)
+	ListUserPermissions_ func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*sourcegraph.UserPermissionsList, error)
 }
 
 func (s *RegisteredClientsClient) Get(ctx context.Context, in *sourcegraph.RegisteredClientSpec, opts ...grpc.CallOption) (*sourcegraph.RegisteredClient, error) {
@@ -1078,7 +1061,7 @@ func (s *RegisteredClientsClient) GetCurrent(ctx context.Context, in *pbtypes.Vo
 	return s.GetCurrent_(ctx, in)
 }
 
-func (s *RegisteredClientsClient) Create(ctx context.Context, in *sourcegraph.RegisteredClientsCreateOp, opts ...grpc.CallOption) (*sourcegraph.RegisteredClient, error) {
+func (s *RegisteredClientsClient) Create(ctx context.Context, in *sourcegraph.RegisteredClient, opts ...grpc.CallOption) (*sourcegraph.RegisteredClient, error) {
 	return s.Create_(ctx, in)
 }
 
@@ -1094,15 +1077,30 @@ func (s *RegisteredClientsClient) List(ctx context.Context, in *sourcegraph.Regi
 	return s.List_(ctx, in)
 }
 
+func (s *RegisteredClientsClient) GetUserPermissions(ctx context.Context, in *sourcegraph.UserPermissionsOptions, opts ...grpc.CallOption) (*sourcegraph.UserPermissions, error) {
+	return s.GetUserPermissions_(ctx, in)
+}
+
+func (s *RegisteredClientsClient) SetUserPermissions(ctx context.Context, in *sourcegraph.UserPermissions, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.SetUserPermissions_(ctx, in)
+}
+
+func (s *RegisteredClientsClient) ListUserPermissions(ctx context.Context, in *sourcegraph.RegisteredClientSpec, opts ...grpc.CallOption) (*sourcegraph.UserPermissionsList, error) {
+	return s.ListUserPermissions_(ctx, in)
+}
+
 var _ sourcegraph.RegisteredClientsClient = (*RegisteredClientsClient)(nil)
 
 type RegisteredClientsServer struct {
-	Get_        func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
-	GetCurrent_ func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
-	Create_     func(v0 context.Context, v1 *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error)
-	Update_     func(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
-	Delete_     func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
-	List_       func(v0 context.Context, v1 *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
+	Get_                 func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
+	GetCurrent_          func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
+	Create_              func(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error)
+	Update_              func(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
+	Delete_              func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
+	List_                func(v0 context.Context, v1 *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
+	GetUserPermissions_  func(v0 context.Context, v1 *sourcegraph.UserPermissionsOptions) (*sourcegraph.UserPermissions, error)
+	SetUserPermissions_  func(v0 context.Context, v1 *sourcegraph.UserPermissions) (*pbtypes.Void, error)
+	ListUserPermissions_ func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.UserPermissionsList, error)
 }
 
 func (s *RegisteredClientsServer) Get(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error) {
@@ -1113,7 +1111,7 @@ func (s *RegisteredClientsServer) GetCurrent(v0 context.Context, v1 *pbtypes.Voi
 	return s.GetCurrent_(v0, v1)
 }
 
-func (s *RegisteredClientsServer) Create(v0 context.Context, v1 *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error) {
+func (s *RegisteredClientsServer) Create(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error) {
 	return s.Create_(v0, v1)
 }
 
@@ -1127,6 +1125,18 @@ func (s *RegisteredClientsServer) Delete(v0 context.Context, v1 *sourcegraph.Reg
 
 func (s *RegisteredClientsServer) List(v0 context.Context, v1 *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error) {
 	return s.List_(v0, v1)
+}
+
+func (s *RegisteredClientsServer) GetUserPermissions(v0 context.Context, v1 *sourcegraph.UserPermissionsOptions) (*sourcegraph.UserPermissions, error) {
+	return s.GetUserPermissions_(v0, v1)
+}
+
+func (s *RegisteredClientsServer) SetUserPermissions(v0 context.Context, v1 *sourcegraph.UserPermissions) (*pbtypes.Void, error) {
+	return s.SetUserPermissions_(v0, v1)
+}
+
+func (s *RegisteredClientsServer) ListUserPermissions(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.UserPermissionsList, error) {
+	return s.ListUserPermissions_(v0, v1)
 }
 
 var _ sourcegraph.RegisteredClientsServer = (*RegisteredClientsServer)(nil)

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -1064,7 +1064,7 @@ var _ sourcegraph.MetaServer = (*MetaServer)(nil)
 type RegisteredClientsClient struct {
 	Get_        func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
 	GetCurrent_ func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
-	Create_     func(ctx context.Context, in *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error)
+	Create_     func(ctx context.Context, in *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error)
 	Update_     func(ctx context.Context, in *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
 	Delete_     func(ctx context.Context, in *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
 	List_       func(ctx context.Context, in *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
@@ -1078,7 +1078,7 @@ func (s *RegisteredClientsClient) GetCurrent(ctx context.Context, in *pbtypes.Vo
 	return s.GetCurrent_(ctx, in)
 }
 
-func (s *RegisteredClientsClient) Create(ctx context.Context, in *sourcegraph.RegisteredClient, opts ...grpc.CallOption) (*sourcegraph.RegisteredClient, error) {
+func (s *RegisteredClientsClient) Create(ctx context.Context, in *sourcegraph.RegisteredClientsCreateOp, opts ...grpc.CallOption) (*sourcegraph.RegisteredClient, error) {
 	return s.Create_(ctx, in)
 }
 
@@ -1099,7 +1099,7 @@ var _ sourcegraph.RegisteredClientsClient = (*RegisteredClientsClient)(nil)
 type RegisteredClientsServer struct {
 	Get_        func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*sourcegraph.RegisteredClient, error)
 	GetCurrent_ func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.RegisteredClient, error)
-	Create_     func(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error)
+	Create_     func(v0 context.Context, v1 *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error)
 	Update_     func(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*pbtypes.Void, error)
 	Delete_     func(v0 context.Context, v1 *sourcegraph.RegisteredClientSpec) (*pbtypes.Void, error)
 	List_       func(v0 context.Context, v1 *sourcegraph.RegisteredClientListOptions) (*sourcegraph.RegisteredClientList, error)
@@ -1113,7 +1113,7 @@ func (s *RegisteredClientsServer) GetCurrent(v0 context.Context, v1 *pbtypes.Voi
 	return s.GetCurrent_(v0, v1)
 }
 
-func (s *RegisteredClientsServer) Create(v0 context.Context, v1 *sourcegraph.RegisteredClient) (*sourcegraph.RegisteredClient, error) {
+func (s *RegisteredClientsServer) Create(v0 context.Context, v1 *sourcegraph.RegisteredClientsCreateOp) (*sourcegraph.RegisteredClient, error) {
 	return s.Create_(v0, v1)
 }
 

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2846,6 +2846,13 @@ message RegisteredClientList {
 	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+message RegisteredClientsCreateOp {
+	RegisteredClient client = 1;
+
+	// UID is the ID of the user registering the client
+	int32 uid = 2 [(gogoproto.customname) = "UID"];
+}
+
 // RegisteredClients manages registered API clients.
 //
 // The server may check authorization for methods that retrieve or
@@ -2863,8 +2870,10 @@ service RegisteredClients {
 	// the currently authenticated client.
 	rpc GetCurrent(pbtypes.Void) returns (RegisteredClient);
 
-	// Create registers an API client.
-	rpc Create(RegisteredClient) returns (RegisteredClient);
+	// Create registers an API client. If RegisteredClientsCreateOp.UID
+	// is non-zero, that user will be assigned admin privileges on
+	// the client.
+	rpc Create(RegisteredClientsCreateOp) returns (RegisteredClient);
 
 	// Update modifies an API client's record. The RegisteredClient
 	// arg's ID must be set (to specify which client to update). Its

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1512,6 +1512,19 @@ message NewAccount {
   string password = 3;
 }
 
+message UserWhitelistOptions {
+	// UID is a user's UID.
+	int32 uid = 1 [(gogoproto.customname) = "UID"];
+
+	// ClientID is the ID of the client whose whitelist is to
+	// be fetched and/or modified.
+	string client_id = 2 [(gogoproto.customname) = "ClientID"];
+
+	// Admin is true if the user should be considered an admin on
+	// the client.
+	bool admin = 3;
+}
+
 // UsersService communicates with the users-related endpoints in the Sourcegraph
 // API.
 service Users {
@@ -1533,6 +1546,22 @@ service Users {
 	rpc List(UsersListOptions) returns (UserList) {
 		option (google.api.http) = {
 			get: "/users/list"
+		};
+	};
+
+	// Check if user is on the client's whitelist.
+	// If UserWhitelistOptions.Admin is set to true, this
+	// will check if the user is an admin on that client.
+	rpc CheckWhitelist(UserWhitelistOptions) returns (pbtypes.Void) {
+		option (google.api.http) = {
+			get: "/users/whitelist"
+		};
+	};
+
+	// Add user to client-specific whitelist.
+	rpc AddToWhitelist(UserWhitelistOptions) returns (pbtypes.Void) {
+		option (google.api.http) = {
+			post: "/users/whitelist"
 		};
 	};
 }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1512,19 +1512,6 @@ message NewAccount {
   string password = 3;
 }
 
-message UserWhitelistOptions {
-	// UID is a user's UID.
-	int32 uid = 1 [(gogoproto.customname) = "UID"];
-
-	// ClientID is the ID of the client whose whitelist is to
-	// be fetched and/or modified.
-	string client_id = 2 [(gogoproto.customname) = "ClientID"];
-
-	// Admin is true if the user should be considered an admin on
-	// the client.
-	bool admin = 3;
-}
-
 // UsersService communicates with the users-related endpoints in the Sourcegraph
 // API.
 service Users {
@@ -1546,22 +1533,6 @@ service Users {
 	rpc List(UsersListOptions) returns (UserList) {
 		option (google.api.http) = {
 			get: "/users/list"
-		};
-	};
-
-	// Check if user is on the client's whitelist.
-	// If UserWhitelistOptions.Admin is set to true, this
-	// will check if the user is an admin on that client.
-	rpc CheckWhitelist(UserWhitelistOptions) returns (pbtypes.Void) {
-		option (google.api.http) = {
-			get: "/users/whitelist"
-		};
-	};
-
-	// Add user to client-specific whitelist.
-	rpc AddToWhitelist(UserWhitelistOptions) returns (pbtypes.Void) {
-		option (google.api.http) = {
-			post: "/users/whitelist"
 		};
 	};
 }
@@ -2846,10 +2817,32 @@ message RegisteredClientList {
 	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
-message RegisteredClientsCreateOp {
-	RegisteredClient client = 1;
+message UserPermissions {
+	// UID is a user's UID.
+	int32 uid = 1 [(gogoproto.customname) = "UID"];
 
-	// UID is the ID of the user registering the client
+	// ClientID is the ID of the client whose whitelist is to
+	// be fetched and/or modified.
+	string client_id = 2 [(gogoproto.customname) = "ClientID"];
+
+	// Read is true if the user has read permissions on the client.
+	bool read = 3;
+
+	// Write is true if the user has write permissions on the client.
+	bool write = 4;
+
+	// Admin is true if the user should be considered an admin on
+	// the client.
+	bool admin = 5;
+}
+
+message UserPermissionsList {
+	repeated UserPermissions user_permissions = 1 [(gogoproto.customname) = "UserPermissions"];
+}
+
+message UserPermissionsOptions {
+	RegisteredClientSpec client_spec = 1 [(gogoproto.customname) = "ClientSpec"];
+
 	int32 uid = 2 [(gogoproto.customname) = "UID"];
 }
 
@@ -2870,10 +2863,8 @@ service RegisteredClients {
 	// the currently authenticated client.
 	rpc GetCurrent(pbtypes.Void) returns (RegisteredClient);
 
-	// Create registers an API client. If RegisteredClientsCreateOp.UID
-	// is non-zero, that user will be assigned admin privileges on
-	// the client.
-	rpc Create(RegisteredClientsCreateOp) returns (RegisteredClient);
+	// Create registers an API client.
+	rpc Create(RegisteredClient) returns (RegisteredClient);
 
 	// Update modifies an API client's record. The RegisteredClient
 	// arg's ID must be set (to specify which client to update). Its
@@ -2887,6 +2878,15 @@ service RegisteredClients {
 
 	// List enumerates API clients according to the options.
 	rpc List(RegisteredClientListOptions) returns (RegisteredClientList);
+
+	// Get the permissions of the user on the specified client.
+	rpc GetUserPermissions(UserPermissionsOptions) returns (UserPermissions);
+
+	// Set the permissions of the user on the specified client.
+	rpc SetUserPermissions(UserPermissions) returns (pbtypes.Void);
+
+	// List the permissions of all users that are registered on this client.
+	rpc ListUserPermissions(RegisteredClientSpec) returns (UserPermissionsList);
 }
 
 // TelemetryType is the format MetricsSnapshot.TelemetryData is encoded in


### PR DESCRIPTION
This PR makes two changes:

- Add Users.CheckWhitelist and Users.AddToWhitelist to add users to a whitelist on the server.
- Change RegisteredClients.Create to take a RegisteredClientsCreateOp which has the client and the user id of the user registering the client. This user should be set as an admin on the client's whitelist.