### PR TITLE
Add fields needed for search pagination

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -3312,6 +3312,28 @@ func (s *CachedSearchServer) Search(ctx context.Context, in *SearchOptions) (*Se
 	return result, err
 }
 
+func (s *CachedSearchServer) SearchTokens(ctx context.Context, in *TokenSearchOptions) (*DefList, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.SearchServer.SearchTokens(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedSearchServer) SearchText(ctx context.Context, in *TextSearchOptions) (*VCSSearchResultList, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.SearchServer.SearchText(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
 func (s *CachedSearchServer) Complete(ctx context.Context, in *RawQuery) (*Completions, error) {
 	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
 	result, err := s.SearchServer.Complete(ctx, in)
@@ -3359,6 +3381,58 @@ func (s *CachedSearchClient) Search(ctx context.Context, in *SearchOptions, opts
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "Search.Search", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedSearchClient) SearchTokens(ctx context.Context, in *TokenSearchOptions, opts ...grpc.CallOption) (*DefList, error) {
+	if s.Cache != nil {
+		var cachedResult DefList
+		cached, err := s.Cache.Get(ctx, "Search.SearchTokens", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.SearchClient.SearchTokens(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Search.SearchTokens", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedSearchClient) SearchText(ctx context.Context, in *TextSearchOptions, opts ...grpc.CallOption) (*VCSSearchResultList, error) {
+	if s.Cache != nil {
+		var cachedResult VCSSearchResultList
+		cached, err := s.Cache.Get(ctx, "Search.SearchText", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.SearchClient.SearchText(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Search.SearchText", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -942,13 +942,23 @@ func (s *RepoTreeServer) List(v0 context.Context, v1 *sourcegraph.RepoTreeListOp
 var _ sourcegraph.RepoTreeServer = (*RepoTreeServer)(nil)
 
 type SearchClient struct {
-	Search_   func(ctx context.Context, in *sourcegraph.SearchOptions) (*sourcegraph.SearchResults, error)
-	Complete_ func(ctx context.Context, in *sourcegraph.RawQuery) (*sourcegraph.Completions, error)
-	Suggest_  func(ctx context.Context, in *sourcegraph.RawQuery) (*sourcegraph.SuggestionList, error)
+	Search_       func(ctx context.Context, in *sourcegraph.SearchOptions) (*sourcegraph.SearchResults, error)
+	SearchTokens_ func(ctx context.Context, in *sourcegraph.TokenSearchOptions) (*sourcegraph.DefList, error)
+	SearchText_   func(ctx context.Context, in *sourcegraph.TextSearchOptions) (*sourcegraph.VCSSearchResultList, error)
+	Complete_     func(ctx context.Context, in *sourcegraph.RawQuery) (*sourcegraph.Completions, error)
+	Suggest_      func(ctx context.Context, in *sourcegraph.RawQuery) (*sourcegraph.SuggestionList, error)
 }
 
 func (s *SearchClient) Search(ctx context.Context, in *sourcegraph.SearchOptions, opts ...grpc.CallOption) (*sourcegraph.SearchResults, error) {
 	return s.Search_(ctx, in)
+}
+
+func (s *SearchClient) SearchTokens(ctx context.Context, in *sourcegraph.TokenSearchOptions, opts ...grpc.CallOption) (*sourcegraph.DefList, error) {
+	return s.SearchTokens_(ctx, in)
+}
+
+func (s *SearchClient) SearchText(ctx context.Context, in *sourcegraph.TextSearchOptions, opts ...grpc.CallOption) (*sourcegraph.VCSSearchResultList, error) {
+	return s.SearchText_(ctx, in)
 }
 
 func (s *SearchClient) Complete(ctx context.Context, in *sourcegraph.RawQuery, opts ...grpc.CallOption) (*sourcegraph.Completions, error) {
@@ -962,13 +972,23 @@ func (s *SearchClient) Suggest(ctx context.Context, in *sourcegraph.RawQuery, op
 var _ sourcegraph.SearchClient = (*SearchClient)(nil)
 
 type SearchServer struct {
-	Search_   func(v0 context.Context, v1 *sourcegraph.SearchOptions) (*sourcegraph.SearchResults, error)
-	Complete_ func(v0 context.Context, v1 *sourcegraph.RawQuery) (*sourcegraph.Completions, error)
-	Suggest_  func(v0 context.Context, v1 *sourcegraph.RawQuery) (*sourcegraph.SuggestionList, error)
+	Search_       func(v0 context.Context, v1 *sourcegraph.SearchOptions) (*sourcegraph.SearchResults, error)
+	SearchTokens_ func(v0 context.Context, v1 *sourcegraph.TokenSearchOptions) (*sourcegraph.DefList, error)
+	SearchText_   func(v0 context.Context, v1 *sourcegraph.TextSearchOptions) (*sourcegraph.VCSSearchResultList, error)
+	Complete_     func(v0 context.Context, v1 *sourcegraph.RawQuery) (*sourcegraph.Completions, error)
+	Suggest_      func(v0 context.Context, v1 *sourcegraph.RawQuery) (*sourcegraph.SuggestionList, error)
 }
 
 func (s *SearchServer) Search(v0 context.Context, v1 *sourcegraph.SearchOptions) (*sourcegraph.SearchResults, error) {
 	return s.Search_(v0, v1)
+}
+
+func (s *SearchServer) SearchTokens(v0 context.Context, v1 *sourcegraph.TokenSearchOptions) (*sourcegraph.DefList, error) {
+	return s.SearchTokens_(v0, v1)
+}
+
+func (s *SearchServer) SearchText(v0 context.Context, v1 *sourcegraph.TextSearchOptions) (*sourcegraph.VCSSearchResultList, error) {
+	return s.SearchText_(v0, v1)
 }
 
 func (s *SearchServer) Complete(v0 context.Context, v1 *sourcegraph.RawQuery) (*sourcegraph.Completions, error) {

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -172,6 +172,8 @@ It has these top-level messages:
 	RepoTreeListOp
 	RepoTreeListResult
 	VCSSearchResultList
+	TokenSearchOptions
+	TextSearchOptions
 	SearchOptions
 	SearchResults
 	SuggestionList
@@ -2507,6 +2509,25 @@ func (m *VCSSearchResultList) Reset()         { *m = VCSSearchResultList{} }
 func (m *VCSSearchResultList) String() string { return proto.CompactTextString(m) }
 func (*VCSSearchResultList) ProtoMessage()    {}
 
+type TokenSearchOptions struct {
+	Query       string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
+	ListOptions `protobuf:"bytes,2,opt,name=list_options,embedded=list_options" json:"list_options"`
+}
+
+func (m *TokenSearchOptions) Reset()         { *m = TokenSearchOptions{} }
+func (m *TokenSearchOptions) String() string { return proto.CompactTextString(m) }
+func (*TokenSearchOptions) ProtoMessage()    {}
+
+type TextSearchOptions struct {
+	Query       string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
+	ListOptions `protobuf:"bytes,2,opt,name=list_options,embedded=list_options" json:"list_options"`
+}
+
+func (m *TextSearchOptions) Reset()         { *m = TextSearchOptions{} }
+func (m *TextSearchOptions) String() string { return proto.CompactTextString(m) }
+func (*TextSearchOptions) ProtoMessage()    {}
+
+// Deprecated.
 type SearchOptions struct {
 	Query       string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
 	Defs        bool   `protobuf:"varint,2,opt,name=defs,proto3" json:"defs,omitempty"`
@@ -2520,6 +2541,7 @@ func (m *SearchOptions) Reset()         { *m = SearchOptions{} }
 func (m *SearchOptions) String() string { return proto.CompactTextString(m) }
 func (*SearchOptions) ProtoMessage()    {}
 
+// Deprecated.
 type SearchResults struct {
 	Defs   []*Def                  `protobuf:"bytes,1,rep,name=defs" json:"defs,omitempty"`
 	People []*Person               `protobuf:"bytes,2,rep,name=people" json:"people,omitempty"`
@@ -5855,7 +5877,13 @@ var _RepoTree_serviceDesc = grpc.ServiceDesc{
 
 type SearchClient interface {
 	// Search searches the full index.
+	// This method is deprecated (use one of the more specific
+	// search methods below)
 	Search(ctx context.Context, in *SearchOptions, opts ...grpc.CallOption) (*SearchResults, error)
+	// SearchTokens searches the index of tokens.
+	SearchTokens(ctx context.Context, in *TokenSearchOptions, opts ...grpc.CallOption) (*DefList, error)
+	// SearchText searches the content of files in the repo tree.
+	SearchText(ctx context.Context, in *TextSearchOptions, opts ...grpc.CallOption) (*VCSSearchResultList, error)
 	// Complete completes the token at the RawQuery's InsertionPoint.
 	Complete(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*Completions, error)
 	// Suggest suggests queries given an existing query. It can be called with an empty
@@ -5875,6 +5903,24 @@ func NewSearchClient(cc *grpc.ClientConn) SearchClient {
 func (c *searchClient) Search(ctx context.Context, in *SearchOptions, opts ...grpc.CallOption) (*SearchResults, error) {
 	out := new(SearchResults)
 	err := grpc.Invoke(ctx, "/sourcegraph.Search/Search", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *searchClient) SearchTokens(ctx context.Context, in *TokenSearchOptions, opts ...grpc.CallOption) (*DefList, error) {
+	out := new(DefList)
+	err := grpc.Invoke(ctx, "/sourcegraph.Search/SearchTokens", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *searchClient) SearchText(ctx context.Context, in *TextSearchOptions, opts ...grpc.CallOption) (*VCSSearchResultList, error) {
+	out := new(VCSSearchResultList)
+	err := grpc.Invoke(ctx, "/sourcegraph.Search/SearchText", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -5903,7 +5949,13 @@ func (c *searchClient) Suggest(ctx context.Context, in *RawQuery, opts ...grpc.C
 
 type SearchServer interface {
 	// Search searches the full index.
+	// This method is deprecated (use one of the more specific
+	// search methods below)
 	Search(context.Context, *SearchOptions) (*SearchResults, error)
+	// SearchTokens searches the index of tokens.
+	SearchTokens(context.Context, *TokenSearchOptions) (*DefList, error)
+	// SearchText searches the content of files in the repo tree.
+	SearchText(context.Context, *TextSearchOptions) (*VCSSearchResultList, error)
 	// Complete completes the token at the RawQuery's InsertionPoint.
 	Complete(context.Context, *RawQuery) (*Completions, error)
 	// Suggest suggests queries given an existing query. It can be called with an empty
@@ -5922,6 +5974,30 @@ func _Search_Search_Handler(srv interface{}, ctx context.Context, codec grpc.Cod
 		return nil, err
 	}
 	out, err := srv.(SearchServer).Search(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Search_SearchTokens_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(TokenSearchOptions)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(SearchServer).SearchTokens(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Search_SearchText_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(TextSearchOptions)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(SearchServer).SearchText(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -5959,6 +6035,14 @@ var _Search_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Search",
 			Handler:    _Search_Search_Handler,
+		},
+		{
+			MethodName: "SearchTokens",
+			Handler:    _Search_SearchTokens_Handler,
+		},
+		{
+			MethodName: "SearchText",
+			Handler:    _Search_SearchText_Handler,
 		},
 		{
 			MethodName: "Complete",

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -5877,8 +5877,7 @@ var _RepoTree_serviceDesc = grpc.ServiceDesc{
 
 type SearchClient interface {
 	// Search searches the full index.
-	// This method is deprecated (use one of the more specific
-	// search methods below)
+	// Deprecated: use one of the more specific search methods below.
 	Search(ctx context.Context, in *SearchOptions, opts ...grpc.CallOption) (*SearchResults, error)
 	// SearchTokens searches the index of tokens.
 	SearchTokens(ctx context.Context, in *TokenSearchOptions, opts ...grpc.CallOption) (*DefList, error)
@@ -5949,8 +5948,7 @@ func (c *searchClient) Suggest(ctx context.Context, in *RawQuery, opts ...grpc.C
 
 type SearchServer interface {
 	// Search searches the full index.
-	// This method is deprecated (use one of the more specific
-	// search methods below)
+	// Deprecated: use one of the more specific search methods below.
 	Search(context.Context, *SearchOptions) (*SearchResults, error)
 	// SearchTokens searches the index of tokens.
 	SearchTokens(context.Context, *TokenSearchOptions) (*DefList, error)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -367,6 +367,8 @@ func (*ListOptions) ProtoMessage()    {}
 type ListResponse struct {
 	// HasMore is true if there are more entries available after the returned page.
 	HasMore bool `protobuf:"varint,1,opt,name=has_more,proto3" json:"has_more,omitempty" url:",omitempty"`
+	// Total is the total number of results in the list.
+	Total int32 `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty" url:",omitempty"`
 }
 
 func (m *ListResponse) Reset()         { *m = ListResponse{} }

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -2021,7 +2021,8 @@ func (m *DefsGetOp) String() string { return proto.CompactTextString(m) }
 func (*DefsGetOp) ProtoMessage()    {}
 
 type DefList struct {
-	Defs []*Def `protobuf:"bytes,1,rep,name=defs" json:"defs,omitempty"`
+	Defs         []*Def `protobuf:"bytes,1,rep,name=defs" json:"defs,omitempty"`
+	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
 }
 
 func (m *DefList) Reset()         { *m = DefList{} }

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -2500,6 +2500,7 @@ func (*RepoTreeListResult) ProtoMessage()    {}
 
 type VCSSearchResultList struct {
 	SearchResults []*vcs.SearchResult `protobuf:"bytes,1,rep,name=search_results" json:"search_results,omitempty"`
+	ListResponse  `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
 }
 
 func (m *VCSSearchResultList) Reset()         { *m = VCSSearchResultList{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2184,6 +2184,7 @@ message RepoTreeListResult {
 
 message VCSSearchResultList {
 	repeated vcs.SearchResult search_results = 1;
+	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message SearchOptions {

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1847,6 +1847,7 @@ message DefsGetOp {
 
 message DefList {
 	repeated Def defs = 1;
+	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message DefsListRefsOp {

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2187,6 +2187,17 @@ message VCSSearchResultList {
 	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+message TokenSearchOptions {
+	string query = 1 [(gogoproto.moretags) = "url:\"q\" schema:\"q\""];
+	ListOptions list_options = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+message TextSearchOptions {
+	string query = 1 [(gogoproto.moretags) = "url:\"q\" schema:\"q\""];
+	ListOptions list_options = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// Deprecated.
 message SearchOptions {
 	string query = 1 [(gogoproto.moretags) = "url:\"q\" schema:\"q\""];
 	bool defs = 2;
@@ -2196,6 +2207,7 @@ message SearchOptions {
 	ListOptions list_options = 6 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// Deprecated.
 message SearchResults {
 	repeated Def defs = 1;
 	repeated Person people = 2;
@@ -2486,9 +2498,25 @@ service RepoTree {
 // API.
 service Search {
 	// Search searches the full index.
+  // This method is deprecated (use one of the more specific
+  // search methods below)
 	rpc Search(SearchOptions) returns (SearchResults) {
 		option (google.api.http) = {
 			post: "/search"
+		};
+	};
+
+	// SearchTokens searches the index of tokens.
+	rpc SearchTokens(TokenSearchOptions) returns (DefList) {
+		option (google.api.http) = {
+			post: "/search/tokens"
+		};
+	};
+
+	// SearchText searches the content of files in the repo tree.
+	rpc SearchText(TextSearchOptions) returns (VCSSearchResultList) {
+		option (google.api.http) = {
+			post: "/search/text"
 		};
 	};
 

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2498,8 +2498,7 @@ service RepoTree {
 // API.
 service Search {
 	// Search searches the full index.
-	// This method is deprecated (use one of the more specific
-	// search methods below)
+	// Deprecated: use one of the more specific search methods below.
 	rpc Search(SearchOptions) returns (SearchResults) {
 		option (google.api.http) = {
 			post: "/search"

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -58,6 +58,9 @@ message ListOptions {
 message ListResponse {
 	// HasMore is true if there are more entries available after the returned page.
 	bool has_more = 1 [(gogoproto.moretags) = "url:\",omitempty\""];
+
+	// Total is the total number of results in the list.
+	int32 total = 2 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
 // Discussion stores information about a discussion

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2498,8 +2498,8 @@ service RepoTree {
 // API.
 service Search {
 	// Search searches the full index.
-  // This method is deprecated (use one of the more specific
-  // search methods below)
+	// This method is deprecated (use one of the more specific
+	// search methods below)
 	rpc Search(SearchOptions) returns (SearchResults) {
 		option (google.api.http) = {
 			post: "/search"


### PR DESCRIPTION
This commit adds a few fields and methods that will make pagination for search easier:

- "Total" field on the ListResponse struct.This is an optional field that specifies the total number of results in the list that the list response represents. This can be used to determine the total number of pages as well.
- "ListResponse" field in DefList. This embeds ListResponse in DefList, so it can use it's fields for pagination. RefList already does this in the same way. 
- "List Response" field in VCSSearchResultsList, for the same reasons above.
- New methods "SearchTokens" and "SearchText", made with the intention of breaking up the now-deprecated monolithic "Search" method for flexibility and simplicity.