### PR TITLE
Add UserEvents message and GraphUplink.PushEvents endpoint

### DIFF
--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -1142,21 +1142,31 @@ func (s *RegisteredClientsServer) ListUserPermissions(v0 context.Context, v1 *so
 var _ sourcegraph.RegisteredClientsServer = (*RegisteredClientsServer)(nil)
 
 type GraphUplinkClient struct {
-	Push_ func(ctx context.Context, in *sourcegraph.MetricsSnapshot) (*pbtypes.Void, error)
+	Push_       func(ctx context.Context, in *sourcegraph.MetricsSnapshot) (*pbtypes.Void, error)
+	PushEvents_ func(ctx context.Context, in *sourcegraph.UserEventList) (*pbtypes.Void, error)
 }
 
 func (s *GraphUplinkClient) Push(ctx context.Context, in *sourcegraph.MetricsSnapshot, opts ...grpc.CallOption) (*pbtypes.Void, error) {
 	return s.Push_(ctx, in)
 }
 
+func (s *GraphUplinkClient) PushEvents(ctx context.Context, in *sourcegraph.UserEventList, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.PushEvents_(ctx, in)
+}
+
 var _ sourcegraph.GraphUplinkClient = (*GraphUplinkClient)(nil)
 
 type GraphUplinkServer struct {
-	Push_ func(v0 context.Context, v1 *sourcegraph.MetricsSnapshot) (*pbtypes.Void, error)
+	Push_       func(v0 context.Context, v1 *sourcegraph.MetricsSnapshot) (*pbtypes.Void, error)
+	PushEvents_ func(v0 context.Context, v1 *sourcegraph.UserEventList) (*pbtypes.Void, error)
 }
 
 func (s *GraphUplinkServer) Push(v0 context.Context, v1 *sourcegraph.MetricsSnapshot) (*pbtypes.Void, error) {
 	return s.Push_(v0, v1)
+}
+
+func (s *GraphUplinkServer) PushEvents(v0 context.Context, v1 *sourcegraph.UserEventList) (*pbtypes.Void, error) {
+	return s.PushEvents_(v0, v1)
 }
 
 var _ sourcegraph.GraphUplinkServer = (*GraphUplinkServer)(nil)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -209,6 +209,8 @@ It has these top-level messages:
 	UserPermissionsList
 	UserPermissionsOptions
 	MetricsSnapshot
+	UserEvent
+	UserEventList
 */
 package sourcegraph
 
@@ -3056,6 +3058,30 @@ type MetricsSnapshot struct {
 func (m *MetricsSnapshot) Reset()         { *m = MetricsSnapshot{} }
 func (m *MetricsSnapshot) String() string { return proto.CompactTextString(m) }
 func (*MetricsSnapshot) ProtoMessage()    {}
+
+// UserEvent encodes any user initiated event on the local instance
+type UserEvent struct {
+	Type     string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	UID      int32  `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	ClientID string `protobuf:"bytes,3,opt,name=client_id,proto3" json:"client_id,omitempty"`
+	Service  string `protobuf:"bytes,4,opt,name=service,proto3" json:"service,omitempty"`
+	Method   string `protobuf:"bytes,5,opt,name=method,proto3" json:"method,omitempty"`
+	Result   string `protobuf:"bytes,6,opt,name=result,proto3" json:"result,omitempty"`
+	// CreatedAt holds the creation time of this changeset.
+	CreatedAt *pbtypes.Timestamp `protobuf:"bytes,7,opt,name=created_at" json:"created_at,omitempty"`
+}
+
+func (m *UserEvent) Reset()         { *m = UserEvent{} }
+func (m *UserEvent) String() string { return proto.CompactTextString(m) }
+func (*UserEvent) ProtoMessage()    {}
+
+type UserEventList struct {
+	Events []*UserEvent `protobuf:"bytes,1,rep,name=events" json:"events,omitempty"`
+}
+
+func (m *UserEventList) Reset()         { *m = UserEventList{} }
+func (m *UserEventList) String() string { return proto.CompactTextString(m) }
+func (*UserEventList) ProtoMessage()    {}
 
 func init() {
 	proto.RegisterEnum("sourcegraph.DiscussionListOrder", DiscussionListOrder_name, DiscussionListOrder_value)
@@ -6452,6 +6478,9 @@ var _RegisteredClients_serviceDesc = grpc.ServiceDesc{
 type GraphUplinkClient interface {
 	// Push sends the latest metrics to the upstream instance
 	Push(ctx context.Context, in *MetricsSnapshot, opts ...grpc.CallOption) (*pbtypes1.Void, error)
+	// PushEvents flushes the local event logs to the upstream
+	// instance
+	PushEvents(ctx context.Context, in *UserEventList, opts ...grpc.CallOption) (*pbtypes1.Void, error)
 }
 
 type graphUplinkClient struct {
@@ -6471,11 +6500,23 @@ func (c *graphUplinkClient) Push(ctx context.Context, in *MetricsSnapshot, opts 
 	return out, nil
 }
 
+func (c *graphUplinkClient) PushEvents(ctx context.Context, in *UserEventList, opts ...grpc.CallOption) (*pbtypes1.Void, error) {
+	out := new(pbtypes1.Void)
+	err := grpc.Invoke(ctx, "/sourcegraph.GraphUplink/PushEvents", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for GraphUplink service
 
 type GraphUplinkServer interface {
 	// Push sends the latest metrics to the upstream instance
 	Push(context.Context, *MetricsSnapshot) (*pbtypes1.Void, error)
+	// PushEvents flushes the local event logs to the upstream
+	// instance
+	PushEvents(context.Context, *UserEventList) (*pbtypes1.Void, error)
 }
 
 func RegisterGraphUplinkServer(s *grpc.Server, srv GraphUplinkServer) {
@@ -6494,6 +6535,18 @@ func _GraphUplink_Push_Handler(srv interface{}, ctx context.Context, codec grpc.
 	return out, nil
 }
 
+func _GraphUplink_PushEvents_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(UserEventList)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(GraphUplinkServer).PushEvents(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _GraphUplink_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sourcegraph.GraphUplink",
 	HandlerType: (*GraphUplinkServer)(nil),
@@ -6501,6 +6554,10 @@ var _GraphUplink_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Push",
 			Handler:    _GraphUplink_Push_Handler,
+		},
+		{
+			MethodName: "PushEvents",
+			Handler:    _GraphUplink_PushEvents_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -3059,7 +3059,7 @@ func (m *MetricsSnapshot) Reset()         { *m = MetricsSnapshot{} }
 func (m *MetricsSnapshot) String() string { return proto.CompactTextString(m) }
 func (*MetricsSnapshot) ProtoMessage()    {}
 
-// UserEvent encodes any user initiated event on the local instance
+// UserEvent encodes any user initiated event on the local instance.
 type UserEvent struct {
 	Type     string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	UID      int32  `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
@@ -3067,7 +3067,7 @@ type UserEvent struct {
 	Service  string `protobuf:"bytes,4,opt,name=service,proto3" json:"service,omitempty"`
 	Method   string `protobuf:"bytes,5,opt,name=method,proto3" json:"method,omitempty"`
 	Result   string `protobuf:"bytes,6,opt,name=result,proto3" json:"result,omitempty"`
-	// CreatedAt holds the creation time of this changeset.
+	// CreatedAt holds the time when this event was logged.
 	CreatedAt *pbtypes.Timestamp `protobuf:"bytes,7,opt,name=created_at" json:"created_at,omitempty"`
 }
 

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2905,7 +2905,7 @@ message MetricsSnapshot {
 	bytes telemetry_data = 2;
 }
 
-// UserEvent encodes any user initiated event on the local instance
+// UserEvent encodes any user initiated event on the local instance.
 message UserEvent {
 	string type = 1;
 
@@ -2919,7 +2919,7 @@ message UserEvent {
 
 	string result = 6;
 
-	// CreatedAt holds the creation time of this changeset.
+	// CreatedAt holds the time when this event was logged.
 	pbtypes.Timestamp created_at = 7;
 }
 

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2905,8 +2905,34 @@ message MetricsSnapshot {
 	bytes telemetry_data = 2;
 }
 
+// UserEvent encodes any user initiated event on the local instance
+message UserEvent {
+	string type = 1;
+
+	int32 uid = 2 [(gogoproto.customname) = "UID"];
+
+	string client_id = 3 [(gogoproto.customname) = "ClientID"];
+
+	string service = 4;
+
+	string method = 5;
+
+	string result = 6;
+
+	// CreatedAt holds the creation time of this changeset.
+	pbtypes.Timestamp created_at = 7;
+}
+
+message UserEventList {
+	repeated UserEvent events = 1; 
+}
+
 // GraphUplink interfaces with the metric collectors.
 service GraphUplink {
 	// Push sends the latest metrics to the upstream instance
 	rpc Push(MetricsSnapshot) returns (pbtypes.Void);
+
+	// PushEvents flushes the local event logs to the upstream
+	// instance
+	rpc PushEvents(UserEventList) returns (pbtypes.Void);
 }


### PR DESCRIPTION
This endpoint can be used to push user events upstream from local instances.