### PR TITLE
Add RepoRev field to Text/TokenSearchOpts

### DIFF
--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -2528,8 +2528,9 @@ func (m *VCSSearchResultList) String() string { return proto.CompactTextString(m
 func (*VCSSearchResultList) ProtoMessage()    {}
 
 type TokenSearchOptions struct {
-	Query       string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
-	ListOptions `protobuf:"bytes,2,opt,name=list_options,embedded=list_options" json:"list_options"`
+	Query       string      `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
+	RepoRev     RepoRevSpec `protobuf:"bytes,2,opt,name=repo_rev" json:"repo_rev"`
+	ListOptions `protobuf:"bytes,3,opt,name=list_options,embedded=list_options" json:"list_options"`
 }
 
 func (m *TokenSearchOptions) Reset()         { *m = TokenSearchOptions{} }
@@ -2537,8 +2538,9 @@ func (m *TokenSearchOptions) String() string { return proto.CompactTextString(m)
 func (*TokenSearchOptions) ProtoMessage()    {}
 
 type TextSearchOptions struct {
-	Query       string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
-	ListOptions `protobuf:"bytes,2,opt,name=list_options,embedded=list_options" json:"list_options"`
+	Query       string      `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" url:"q" schema:"q"`
+	RepoRev     RepoRevSpec `protobuf:"bytes,2,opt,name=repo_rev" json:"repo_rev"`
+	ListOptions `protobuf:"bytes,3,opt,name=list_options,embedded=list_options" json:"list_options"`
 }
 
 func (m *TextSearchOptions) Reset()         { *m = TextSearchOptions{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2205,12 +2205,14 @@ message VCSSearchResultList {
 
 message TokenSearchOptions {
 	string query = 1 [(gogoproto.moretags) = "url:\"q\" schema:\"q\""];
-	ListOptions list_options = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	RepoRevSpec repo_rev = 2 [(gogoproto.nullable) = false];
+	ListOptions list_options = 3 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message TextSearchOptions {
 	string query = 1 [(gogoproto.moretags) = "url:\"q\" schema:\"q\""];
-	ListOptions list_options = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	RepoRevSpec repo_rev = 2 [(gogoproto.nullable) = false];
+	ListOptions list_options = 3 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 // Deprecated.


### PR DESCRIPTION
Added a field to the new search options structs that I realized is necessary while working on the new text search implementation. Each options struct needs a `RepoRev` to pass into the the Search methods so the search can be appropriately scoped to the correct repo and rev. 

Right now the new token search method is getting away with embedding the RepoURI in the query as a string, which is similar to how the old def search worked but kind of messy since it has to be parsed out. With this change we can properly pass it in as a struct instead.   