### PR TITLE
Split ListResponse into two separate pagination structs

### DIFF
--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -14,6 +14,7 @@ It has these top-level messages:
 	Counter
 	ListOptions
 	ListResponse
+	StreamResponse
 	Discussion
 	DiscussionComment
 	Changeset
@@ -368,17 +369,26 @@ func (m *ListOptions) Reset()         { *m = ListOptions{} }
 func (m *ListOptions) String() string { return proto.CompactTextString(m) }
 func (*ListOptions) ProtoMessage()    {}
 
-// ListResponse specifies general pagination response when fetching a list of results.
+// ListResponse specifies a general paginated response when fetching a list of results.
 type ListResponse struct {
-	// HasMore is true if there are more entries available after the returned page.
-	HasMore bool `protobuf:"varint,1,opt,name=has_more,proto3" json:"has_more,omitempty" url:",omitempty"`
 	// Total is the total number of results in the list.
-	Total int32 `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty" url:",omitempty"`
+	Total int32 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty" url:",omitempty"`
 }
 
 func (m *ListResponse) Reset()         { *m = ListResponse{} }
 func (m *ListResponse) String() string { return proto.CompactTextString(m) }
 func (*ListResponse) ProtoMessage()    {}
+
+// StreamResponse specifies a paginated response where the total number of results
+// that can be returned is too expensive to compute, unbounded, or unknown.
+type StreamResponse struct {
+	// HasMore is true if there are more results available after the returned page.
+	HasMore bool `protobuf:"varint,1,opt,name=has_more,proto3" json:"has_more,omitempty" url:",omitempty"`
+}
+
+func (m *StreamResponse) Reset()         { *m = StreamResponse{} }
+func (m *StreamResponse) String() string { return proto.CompactTextString(m) }
+func (*StreamResponse) ProtoMessage()    {}
 
 // Discussion stores information about a discussion
 type Discussion struct {
@@ -855,8 +865,8 @@ func (m *RepoListCommitsOptions) String() string { return proto.CompactTextStrin
 func (*RepoListCommitsOptions) ProtoMessage()    {}
 
 type CommitList struct {
-	Commits      []*vcs.Commit `protobuf:"bytes,1,rep,name=commits" json:"commits,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Commits        []*vcs.Commit `protobuf:"bytes,1,rep,name=commits" json:"commits,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *CommitList) Reset()         { *m = CommitList{} }
@@ -884,8 +894,8 @@ func (m *RepoListBranchesOptions) String() string { return proto.CompactTextStri
 func (*RepoListBranchesOptions) ProtoMessage()    {}
 
 type BranchList struct {
-	Branches     []*vcs.Branch `protobuf:"bytes,1,rep,name=branches" json:"branches,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Branches       []*vcs.Branch `protobuf:"bytes,1,rep,name=branches" json:"branches,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *BranchList) Reset()         { *m = BranchList{} }
@@ -920,8 +930,8 @@ func (m *RepoListCommittersOptions) String() string { return proto.CompactTextSt
 func (*RepoListCommittersOptions) ProtoMessage()    {}
 
 type CommitterList struct {
-	Committers   []*vcs.Committer `protobuf:"bytes,1,rep,name=committers" json:"committers,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Committers     []*vcs.Committer `protobuf:"bytes,1,rep,name=committers" json:"committers,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *CommitterList) Reset()         { *m = CommitterList{} }
@@ -1036,8 +1046,8 @@ func (m *RepoListTagsOptions) String() string { return proto.CompactTextString(m
 func (*RepoListTagsOptions) ProtoMessage()    {}
 
 type TagList struct {
-	Tags         []*vcs.Tag `protobuf:"bytes,1,rep,name=tags" json:"tags,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Tags           []*vcs.Tag `protobuf:"bytes,1,rep,name=tags" json:"tags,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *TagList) Reset()         { *m = TagList{} }
@@ -1337,8 +1347,8 @@ func (m *BuildsGetRepoBuildInfoOp) String() string { return proto.CompactTextStr
 func (*BuildsGetRepoBuildInfoOp) ProtoMessage()    {}
 
 type BuildList struct {
-	Builds       []*Build `protobuf:"bytes,1,rep,name=builds" json:"builds,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Builds         []*Build `protobuf:"bytes,1,rep,name=builds" json:"builds,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *BuildList) Reset()         { *m = BuildList{} }
@@ -2059,8 +2069,8 @@ func (m *DefsListRefsOp) String() string { return proto.CompactTextString(m) }
 func (*DefsListRefsOp) ProtoMessage()    {}
 
 type RefList struct {
-	Refs         []*Ref `protobuf:"bytes,1,rep,name=refs" json:"refs,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Refs           []*Ref `protobuf:"bytes,1,rep,name=refs" json:"refs,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *RefList) Reset()         { *m = RefList{} }
@@ -2080,8 +2090,8 @@ func (m *DefsListExamplesOp) String() string { return proto.CompactTextString(m)
 func (*DefsListExamplesOp) ProtoMessage()    {}
 
 type ExampleList struct {
-	Examples     []*Example `protobuf:"bytes,1,rep,name=examples" json:"examples,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Examples       []*Example `protobuf:"bytes,1,rep,name=examples" json:"examples,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *ExampleList) Reset()         { *m = ExampleList{} }
@@ -3047,8 +3057,8 @@ func (*RegisteredClientListOptions) ProtoMessage()    {}
 
 // RegisteredClientList holds a list of clients.
 type RegisteredClientList struct {
-	Clients      []*RegisteredClient `protobuf:"bytes,1,rep,name=clients" json:"clients,omitempty"`
-	ListResponse `protobuf:"bytes,2,opt,name=list_response,embedded=list_response" json:"list_response"`
+	Clients        []*RegisteredClient `protobuf:"bytes,1,rep,name=clients" json:"clients,omitempty"`
+	StreamResponse `protobuf:"bytes,2,opt,name=stream_response,embedded=stream_response" json:"stream_response"`
 }
 
 func (m *RegisteredClientList) Reset()         { *m = RegisteredClientList{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -54,13 +54,17 @@ message ListOptions {
 	int32 page = 2 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
-// ListResponse specifies general pagination response when fetching a list of results.
+// ListResponse specifies a general paginated response when fetching a list of results.
 message ListResponse {
-	// HasMore is true if there are more entries available after the returned page.
-	bool has_more = 1 [(gogoproto.moretags) = "url:\",omitempty\""];
-
 	// Total is the total number of results in the list.
-	int32 total = 2 [(gogoproto.moretags) = "url:\",omitempty\""];
+	int32 total = 1 [(gogoproto.moretags) = "url:\",omitempty\""];
+}
+
+// StreamResponse specifies a paginated response where the total number of results
+// that can be returned is too expensive to compute, unbounded, or unknown.
+message StreamResponse {
+	// HasMore is true if there are more results available after the returned page.
+	bool has_more = 1 [(gogoproto.moretags) = "url:\",omitempty\""];
 }
 
 // Discussion stores information about a discussion
@@ -682,7 +686,7 @@ message RepoListCommitsOptions {
 
 message CommitList {
 	repeated vcs.Commit commits = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message ReposListBranchesOp {
@@ -699,7 +703,7 @@ message RepoListBranchesOptions {
 
 message BranchList {
 	repeated vcs.Branch branches = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message ReposListTagsOp {
@@ -719,7 +723,7 @@ message RepoListCommittersOptions {
 
 message CommitterList {
 	repeated vcs.Committer committers = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message ChangesetCreateOp {
@@ -806,7 +810,7 @@ message RepoListTagsOptions {
 
 message TagList {
 	repeated vcs.Tag tags = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message MirrorReposRefreshVCSOp {
@@ -1101,7 +1105,7 @@ message BuildsGetRepoBuildInfoOp {
 
 message BuildList {
 	repeated Build builds = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message BuildsCreateOp {
@@ -1873,7 +1877,7 @@ message DefsListRefsOp {
 
 message RefList {
 	repeated Ref refs = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message DefsListExamplesOp {
@@ -1886,7 +1890,7 @@ message DefsListExamplesOp {
 
 message ExampleList {
 	repeated Example examples = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message DefsListAuthorsOp {
@@ -2864,7 +2868,7 @@ message RegisteredClientListOptions {
 // RegisteredClientList holds a list of clients.
 message RegisteredClientList {
 	repeated RegisteredClient clients = 1;
-	ListResponse list_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+	StreamResponse stream_response = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
 message UserPermissions {


### PR DESCRIPTION
We discovered while working on search we discovered there are two types of paginated responses. One is when you know the total number of results ahead of time, and the other is when you don't. Prior to this change the ListResponse had two fields, one for each of these cases. 

We realized it doesn't make sense to cover both situations in one struct so now this has been split into `ListResponse` for responses return a total number of results, and a `StreamResponse`, for responses with a currently unknown or unbounded total.

I have already tested the impact of this change on the Sourcegraph repo locally and once everything was converted to the right type of struct it worked well. 

@shurcooL 