### PR TITLE
Notify service

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -1992,6 +1992,87 @@ func (s *CachedMirroredRepoSSHKeysClient) Delete(ctx context.Context, in *RepoSp
 	return result, nil
 }
 
+type CachedNotifyServer struct{ NotifyServer }
+
+func (s *CachedNotifyServer) GenericEvent(ctx context.Context, in *NotifyGenericEvent) (*pbtypes.Void, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.NotifyServer.GenericEvent(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+func (s *CachedNotifyServer) Mention(ctx context.Context, in *NotifyMention) (*pbtypes.Void, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.NotifyServer.Mention(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
+type CachedNotifyClient struct {
+	NotifyClient
+	Cache *grpccache.Cache
+}
+
+func (s *CachedNotifyClient) GenericEvent(ctx context.Context, in *NotifyGenericEvent, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	if s.Cache != nil {
+		var cachedResult pbtypes.Void
+		cached, err := s.Cache.Get(ctx, "Notify.GenericEvent", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.NotifyClient.GenericEvent(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Notify.GenericEvent", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedNotifyClient) Mention(ctx context.Context, in *NotifyMention, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	if s.Cache != nil {
+		var cachedResult pbtypes.Void
+		cached, err := s.Cache.Get(ctx, "Notify.Mention", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.NotifyClient.Mention(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Notify.Mention", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
 type CachedOrgsServer struct{ OrgsServer }
 
 func (s *CachedOrgsServer) Get(ctx context.Context, in *OrgSpec) (*Org, error) {

--- a/sourcegraph/client.go
+++ b/sourcegraph/client.go
@@ -20,6 +20,7 @@ type Client struct {
 	Meta                MetaClient
 	MirrorRepos         MirrorReposClient
 	MirroredRepoSSHKeys MirroredRepoSSHKeysClient
+	Notify              NotifyClient
 	Orgs                OrgsClient
 	People              PeopleClient
 	RegisteredClients   RegisteredClientsClient
@@ -57,6 +58,7 @@ func NewClient(conn *grpc.ClientConn) *Client {
 	c.Meta = &CachedMetaClient{NewMetaClient(conn), Cache}
 	c.MirrorRepos = &CachedMirrorReposClient{NewMirrorReposClient(conn), Cache}
 	c.MirroredRepoSSHKeys = &CachedMirroredRepoSSHKeysClient{NewMirroredRepoSSHKeysClient(conn), Cache}
+	c.Notify = &CachedNotifyClient{NewNotifyClient(conn), Cache}
 	c.Orgs = &CachedOrgsClient{NewOrgsClient(conn), Cache}
 	c.People = &CachedPeopleClient{NewPeopleClient(conn), Cache}
 	c.RegisteredClients = &CachedRegisteredClientsClient{NewRegisteredClientsClient(conn), Cache}

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -1200,3 +1200,33 @@ func (s *GraphUplinkServer) PushEvents(v0 context.Context, v1 *sourcegraph.UserE
 }
 
 var _ sourcegraph.GraphUplinkServer = (*GraphUplinkServer)(nil)
+
+type NotifyClient struct {
+	GenericEvent_ func(ctx context.Context, in *sourcegraph.NotifyGenericEvent) (*pbtypes.Void, error)
+	Mention_      func(ctx context.Context, in *sourcegraph.NotifyMention) (*pbtypes.Void, error)
+}
+
+func (s *NotifyClient) GenericEvent(ctx context.Context, in *sourcegraph.NotifyGenericEvent, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.GenericEvent_(ctx, in)
+}
+
+func (s *NotifyClient) Mention(ctx context.Context, in *sourcegraph.NotifyMention, opts ...grpc.CallOption) (*pbtypes.Void, error) {
+	return s.Mention_(ctx, in)
+}
+
+var _ sourcegraph.NotifyClient = (*NotifyClient)(nil)
+
+type NotifyServer struct {
+	GenericEvent_ func(v0 context.Context, v1 *sourcegraph.NotifyGenericEvent) (*pbtypes.Void, error)
+	Mention_      func(v0 context.Context, v1 *sourcegraph.NotifyMention) (*pbtypes.Void, error)
+}
+
+func (s *NotifyServer) GenericEvent(v0 context.Context, v1 *sourcegraph.NotifyGenericEvent) (*pbtypes.Void, error) {
+	return s.GenericEvent_(v0, v1)
+}
+
+func (s *NotifyServer) Mention(v0 context.Context, v1 *sourcegraph.NotifyMention) (*pbtypes.Void, error) {
+	return s.Mention_(v0, v1)
+}
+
+var _ sourcegraph.NotifyServer = (*NotifyServer)(nil)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -215,6 +215,8 @@ It has these top-level messages:
 	MetricsSnapshot
 	UserEvent
 	UserEventList
+	NotifyGenericEvent
+	NotifyMention
 */
 package sourcegraph
 
@@ -3146,6 +3148,48 @@ type UserEventList struct {
 func (m *UserEventList) Reset()         { *m = UserEventList{} }
 func (m *UserEventList) String() string { return proto.CompactTextString(m) }
 func (*UserEventList) ProtoMessage()    {}
+
+// NotifyGenericEvent describes an action being done against an object. For
+// example reviewing a changeset.
+type NotifyGenericEvent struct {
+	// Actor is the User who did the action
+	Actor *UserSpec `protobuf:"bytes,1,opt,name=actor" json:"actor,omitempty"`
+	// Recipients is who should be notified of the action
+	Recipients []*UserSpec `protobuf:"bytes,2,rep,name=recipients" json:"recipients,omitempty"`
+	// ActionType example: "reviewed"
+	ActionType string `protobuf:"bytes,3,opt,name=action_type,proto3" json:"action_type,omitempty"`
+	// ActionContent example: "Please add tests for the new functionality"
+	ActionContent string `protobuf:"bytes,4,opt,name=action_content,proto3" json:"action_content,omitempty"`
+	// ObjectID example: 71
+	ObjectID int64 `protobuf:"varint,5,opt,name=object_id,proto3" json:"object_id,omitempty"`
+	// ObjectRepo example: "gorilla/mux"
+	ObjectRepo string `protobuf:"bytes,6,opt,name=object_repo,proto3" json:"object_repo,omitempty"`
+	// ObjectType example: "changeset"
+	ObjectType string `protobuf:"bytes,7,opt,name=object_type,proto3" json:"object_type,omitempty"`
+	// ObjectTitle example: "search: Simplify tokenizer"
+	ObjectTitle string `protobuf:"bytes,8,opt,name=object_title,proto3" json:"object_title,omitempty"`
+	// ObjectURL example: "https://src.sourcegraph.com/sourcegraph/.changesets/71"
+	ObjectURL string `protobuf:"bytes,9,opt,name=object_url,proto3" json:"object_url,omitempty"`
+}
+
+func (m *NotifyGenericEvent) Reset()         { *m = NotifyGenericEvent{} }
+func (m *NotifyGenericEvent) String() string { return proto.CompactTextString(m) }
+func (*NotifyGenericEvent) ProtoMessage()    {}
+
+type NotifyMention struct {
+	// Actor is the User who did the mention
+	Actor *UserSpec `protobuf:"bytes,1,opt,name=actor" json:"actor,omitempty"`
+	// Mentioned is a list of users mentioned, which need to be notified
+	Mentioned []*UserSpec `protobuf:"bytes,2,rep,name=mentioned" json:"mentioned,omitempty"`
+	// Where is a text representing where a user was mentioned.
+	Where string `protobuf:"bytes,3,opt,name=where,proto3" json:"where,omitempty"`
+	// WhereURL is the URL that leads to the place where the mention occurred.
+	WhereURL string `protobuf:"bytes,4,opt,name=where_url,proto3" json:"where_url,omitempty"`
+}
+
+func (m *NotifyMention) Reset()         { *m = NotifyMention{} }
+func (m *NotifyMention) String() string { return proto.CompactTextString(m) }
+func (*NotifyMention) ProtoMessage()    {}
 
 func init() {
 	proto.RegisterEnum("sourcegraph.DiscussionListOrder", DiscussionListOrder_name, DiscussionListOrder_value)
@@ -6711,6 +6755,94 @@ var _GraphUplink_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PushEvents",
 			Handler:    _GraphUplink_PushEvents_Handler,
+		},
+	},
+	Streams: []grpc.StreamDesc{},
+}
+
+// Client API for Notify service
+
+type NotifyClient interface {
+	// GenericEvent will notify recipients of an event which happened
+	GenericEvent(ctx context.Context, in *NotifyGenericEvent, opts ...grpc.CallOption) (*pbtypes1.Void, error)
+	// Mention will notify users when they are mentioned
+	Mention(ctx context.Context, in *NotifyMention, opts ...grpc.CallOption) (*pbtypes1.Void, error)
+}
+
+type notifyClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewNotifyClient(cc *grpc.ClientConn) NotifyClient {
+	return &notifyClient{cc}
+}
+
+func (c *notifyClient) GenericEvent(ctx context.Context, in *NotifyGenericEvent, opts ...grpc.CallOption) (*pbtypes1.Void, error) {
+	out := new(pbtypes1.Void)
+	err := grpc.Invoke(ctx, "/sourcegraph.Notify/GenericEvent", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *notifyClient) Mention(ctx context.Context, in *NotifyMention, opts ...grpc.CallOption) (*pbtypes1.Void, error) {
+	out := new(pbtypes1.Void)
+	err := grpc.Invoke(ctx, "/sourcegraph.Notify/Mention", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Server API for Notify service
+
+type NotifyServer interface {
+	// GenericEvent will notify recipients of an event which happened
+	GenericEvent(context.Context, *NotifyGenericEvent) (*pbtypes1.Void, error)
+	// Mention will notify users when they are mentioned
+	Mention(context.Context, *NotifyMention) (*pbtypes1.Void, error)
+}
+
+func RegisterNotifyServer(s *grpc.Server, srv NotifyServer) {
+	s.RegisterService(&_Notify_serviceDesc, srv)
+}
+
+func _Notify_GenericEvent_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(NotifyGenericEvent)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(NotifyServer).GenericEvent(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Notify_Mention_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+	in := new(NotifyMention)
+	if err := codec.Unmarshal(buf, in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(NotifyServer).Mention(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+var _Notify_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "sourcegraph.Notify",
+	HandlerType: (*NotifyServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GenericEvent",
+			Handler:    _Notify_GenericEvent_Handler,
+		},
+		{
+			MethodName: "Mention",
+			Handler:    _Notify_Mention_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -2993,7 +2993,7 @@ message UserEvent {
 }
 
 message UserEventList {
-	repeated UserEvent events = 1; 
+	repeated UserEvent events = 1;
 }
 
 // GraphUplink interfaces with the metric collectors.
@@ -3004,4 +3004,59 @@ service GraphUplink {
 	// PushEvents flushes the local event logs to the upstream
 	// instance
 	rpc PushEvents(UserEventList) returns (pbtypes.Void);
+}
+
+// NotifyGenericEvent describes an action being done against an object. For
+// example reviewing a changeset.
+message NotifyGenericEvent {
+	// Actor is the User who did the action
+	UserSpec actor = 1;
+
+	// Recipients is who should be notified of the action
+	repeated UserSpec recipients = 2;
+
+	// ActionType example: "reviewed"
+	string action_type = 3;
+
+	// ActionContent example: "Please add tests for the new functionality"
+	string action_content = 4;
+
+	// ObjectID example: 71
+	int64 object_id = 5 [(gogoproto.customname) = "ObjectID"];
+
+	// ObjectRepo example: "gorilla/mux"
+	string object_repo = 6;
+
+	// ObjectType example: "changeset"
+	string object_type = 7;
+
+	// ObjectTitle example: "search: Simplify tokenizer"
+	string object_title = 8;
+
+	// ObjectURL example: "https://src.sourcegraph.com/sourcegraph/.changesets/71"
+	string object_url = 9 [(gogoproto.customname) = "ObjectURL"];
+}
+
+
+message NotifyMention {
+	// Actor is the User who did the mention
+	UserSpec actor = 1;
+
+	// Mentioned is a list of users mentioned, which need to be notified
+	repeated UserSpec mentioned = 2;
+
+	// Where is a text representing where a user was mentioned.
+	string where = 3;
+
+	// WhereURL is the URL that leads to the place where the mention occurred.
+	string where_url = 4 [(gogoproto.customname) = "WhereURL"];
+}
+
+// Notify service
+service Notify {
+	// GenericEvent will notify recipients of an event which happened
+	rpc GenericEvent(NotifyGenericEvent) returns (pbtypes.Void);
+
+	// Mention will notify users when they are mentioned
+	rpc Mention(NotifyMention) returns (pbtypes.Void);
 }


### PR DESCRIPTION
Notify Service will allow Sourcegraph instances to not have their own email service setup, but still easily send email notifications (and possibly more in the future).

We should be able to prevent spam/abuse of this since the message payloads pass in UserSpecs. So we can check if the authenticated user is allowed to message such users.