### PR TITLE
Windows support

### DIFF
--- a/routevar/tree.go
+++ b/routevar/tree.go
@@ -2,7 +2,7 @@ package routevar
 
 import (
 	"net/http"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/sourcegraph/mux"
@@ -14,7 +14,7 @@ var TreeEntryPath = `{Path:(?:/.*)*}`
 // FixTreeEntryVars is a mux.PostMatchFunc that cleans and normalizes
 // the path to a tree entry.
 func FixTreeEntryVars(req *http.Request, match *mux.RouteMatch, r *mux.Route) {
-	path := filepath.Clean(strings.TrimPrefix(match.Vars["Path"], "/"))
+	path := path.Clean(strings.TrimPrefix(match.Vars["Path"], "/"))
 	if path == "" || path == "." {
 		match.Vars["Path"] = "."
 	} else {

--- a/sourcegraph/context_test.go
+++ b/sourcegraph/context_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPerRPCCredentials(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sourcegraph/query_tokens.go
+++ b/sourcegraph/query_tokens.go
@@ -3,7 +3,7 @@ package sourcegraph
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"reflect"
 	"strings"
 )
@@ -51,7 +51,7 @@ func (t UnitToken) Token() string {
 	return s
 }
 
-func (t FileToken) Token() string { return "/" + filepath.Clean(t.Path) }
+func (t FileToken) Token() string { return "/" + path.Clean(t.Path) }
 
 func (t UserToken) Token() string { return "@" + t.Login }
 


### PR DESCRIPTION
- using path.Clean instead of filepath.Clean to produce proper URI path
- fixed unit test on Windows (when starting local server, listening on "localhost:0" instead of ":0", otherwise getting "transport: dial tcp [::]:50605: connectex: The requested address is not valid in its context."