### PR TITLE
 sourcegraph: add Changesets.UpdateAffected method

### DIFF
--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -322,14 +322,15 @@ func (s *StorageServer) Close(v0 context.Context, v1 *sourcegraph.StorageName) (
 var _ sourcegraph.StorageServer = (*StorageServer)(nil)
 
 type ChangesetsClient struct {
-	Create_       func(ctx context.Context, in *sourcegraph.ChangesetCreateOp) (*sourcegraph.Changeset, error)
-	Get_          func(ctx context.Context, in *sourcegraph.ChangesetSpec) (*sourcegraph.Changeset, error)
-	List_         func(ctx context.Context, in *sourcegraph.ChangesetListOp) (*sourcegraph.ChangesetList, error)
-	Update_       func(ctx context.Context, in *sourcegraph.ChangesetUpdateOp) (*sourcegraph.ChangesetEvent, error)
-	Merge_        func(ctx context.Context, in *sourcegraph.ChangesetMergeOp) (*sourcegraph.ChangesetEvent, error)
-	CreateReview_ func(ctx context.Context, in *sourcegraph.ChangesetCreateReviewOp) (*sourcegraph.ChangesetReview, error)
-	ListReviews_  func(ctx context.Context, in *sourcegraph.ChangesetListReviewsOp) (*sourcegraph.ChangesetReviewList, error)
-	ListEvents_   func(ctx context.Context, in *sourcegraph.ChangesetSpec) (*sourcegraph.ChangesetEventList, error)
+	Create_         func(ctx context.Context, in *sourcegraph.ChangesetCreateOp) (*sourcegraph.Changeset, error)
+	Get_            func(ctx context.Context, in *sourcegraph.ChangesetSpec) (*sourcegraph.Changeset, error)
+	List_           func(ctx context.Context, in *sourcegraph.ChangesetListOp) (*sourcegraph.ChangesetList, error)
+	Update_         func(ctx context.Context, in *sourcegraph.ChangesetUpdateOp) (*sourcegraph.ChangesetEvent, error)
+	Merge_          func(ctx context.Context, in *sourcegraph.ChangesetMergeOp) (*sourcegraph.ChangesetEvent, error)
+	UpdateAffected_ func(ctx context.Context, in *sourcegraph.ChangesetUpdateAffectedOp) (*sourcegraph.ChangesetEventList, error)
+	CreateReview_   func(ctx context.Context, in *sourcegraph.ChangesetCreateReviewOp) (*sourcegraph.ChangesetReview, error)
+	ListReviews_    func(ctx context.Context, in *sourcegraph.ChangesetListReviewsOp) (*sourcegraph.ChangesetReviewList, error)
+	ListEvents_     func(ctx context.Context, in *sourcegraph.ChangesetSpec) (*sourcegraph.ChangesetEventList, error)
 }
 
 func (s *ChangesetsClient) Create(ctx context.Context, in *sourcegraph.ChangesetCreateOp, opts ...grpc.CallOption) (*sourcegraph.Changeset, error) {
@@ -352,6 +353,10 @@ func (s *ChangesetsClient) Merge(ctx context.Context, in *sourcegraph.ChangesetM
 	return s.Merge_(ctx, in)
 }
 
+func (s *ChangesetsClient) UpdateAffected(ctx context.Context, in *sourcegraph.ChangesetUpdateAffectedOp, opts ...grpc.CallOption) (*sourcegraph.ChangesetEventList, error) {
+	return s.UpdateAffected_(ctx, in)
+}
+
 func (s *ChangesetsClient) CreateReview(ctx context.Context, in *sourcegraph.ChangesetCreateReviewOp, opts ...grpc.CallOption) (*sourcegraph.ChangesetReview, error) {
 	return s.CreateReview_(ctx, in)
 }
@@ -367,14 +372,15 @@ func (s *ChangesetsClient) ListEvents(ctx context.Context, in *sourcegraph.Chang
 var _ sourcegraph.ChangesetsClient = (*ChangesetsClient)(nil)
 
 type ChangesetsServer struct {
-	Create_       func(v0 context.Context, v1 *sourcegraph.ChangesetCreateOp) (*sourcegraph.Changeset, error)
-	Get_          func(v0 context.Context, v1 *sourcegraph.ChangesetSpec) (*sourcegraph.Changeset, error)
-	List_         func(v0 context.Context, v1 *sourcegraph.ChangesetListOp) (*sourcegraph.ChangesetList, error)
-	Update_       func(v0 context.Context, v1 *sourcegraph.ChangesetUpdateOp) (*sourcegraph.ChangesetEvent, error)
-	Merge_        func(v0 context.Context, v1 *sourcegraph.ChangesetMergeOp) (*sourcegraph.ChangesetEvent, error)
-	CreateReview_ func(v0 context.Context, v1 *sourcegraph.ChangesetCreateReviewOp) (*sourcegraph.ChangesetReview, error)
-	ListReviews_  func(v0 context.Context, v1 *sourcegraph.ChangesetListReviewsOp) (*sourcegraph.ChangesetReviewList, error)
-	ListEvents_   func(v0 context.Context, v1 *sourcegraph.ChangesetSpec) (*sourcegraph.ChangesetEventList, error)
+	Create_         func(v0 context.Context, v1 *sourcegraph.ChangesetCreateOp) (*sourcegraph.Changeset, error)
+	Get_            func(v0 context.Context, v1 *sourcegraph.ChangesetSpec) (*sourcegraph.Changeset, error)
+	List_           func(v0 context.Context, v1 *sourcegraph.ChangesetListOp) (*sourcegraph.ChangesetList, error)
+	Update_         func(v0 context.Context, v1 *sourcegraph.ChangesetUpdateOp) (*sourcegraph.ChangesetEvent, error)
+	Merge_          func(v0 context.Context, v1 *sourcegraph.ChangesetMergeOp) (*sourcegraph.ChangesetEvent, error)
+	UpdateAffected_ func(v0 context.Context, v1 *sourcegraph.ChangesetUpdateAffectedOp) (*sourcegraph.ChangesetEventList, error)
+	CreateReview_   func(v0 context.Context, v1 *sourcegraph.ChangesetCreateReviewOp) (*sourcegraph.ChangesetReview, error)
+	ListReviews_    func(v0 context.Context, v1 *sourcegraph.ChangesetListReviewsOp) (*sourcegraph.ChangesetReviewList, error)
+	ListEvents_     func(v0 context.Context, v1 *sourcegraph.ChangesetSpec) (*sourcegraph.ChangesetEventList, error)
 }
 
 func (s *ChangesetsServer) Create(v0 context.Context, v1 *sourcegraph.ChangesetCreateOp) (*sourcegraph.Changeset, error) {
@@ -395,6 +401,10 @@ func (s *ChangesetsServer) Update(v0 context.Context, v1 *sourcegraph.ChangesetU
 
 func (s *ChangesetsServer) Merge(v0 context.Context, v1 *sourcegraph.ChangesetMergeOp) (*sourcegraph.ChangesetEvent, error) {
 	return s.Merge_(v0, v1)
+}
+
+func (s *ChangesetsServer) UpdateAffected(v0 context.Context, v1 *sourcegraph.ChangesetUpdateAffectedOp) (*sourcegraph.ChangesetEventList, error) {
+	return s.UpdateAffected_(v0, v1)
 }
 
 func (s *ChangesetsServer) CreateReview(v0 context.Context, v1 *sourcegraph.ChangesetCreateReviewOp) (*sourcegraph.ChangesetReview, error) {

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -1224,9 +1224,9 @@ type ChangesetUpdateAffectedOp struct {
 	Repo RepoSpec `protobuf:"bytes,1,opt,name=repo" json:"repo"`
 	// Branch is the name of the branch which was pushed to.
 	Branch string `protobuf:"bytes,2,opt,name=branch,proto3" json:"branch,omitempty"`
-	// Last is the SHA1 of the previous commit on the branch.
+	// Last is the SHA1 of the last commit on the branch.
 	Last string `protobuf:"bytes,3,opt,name=last,proto3" json:"last,omitempty"`
-	// Commit is the SHA1 of the newly pushed commit on the branch.
+	// Commit is the SHA1 of the tip of the newly pushed commits on the branch.
 	Commit string `protobuf:"bytes,4,opt,name=commit,proto3" json:"commit,omitempty"`
 }
 
@@ -4700,7 +4700,7 @@ type ChangesetsClient interface {
 	// If no merge occurred, it returns nil.
 	Merge(ctx context.Context, in *ChangesetMergeOp, opts ...grpc.CallOption) (*ChangesetEvent, error)
 	// UpdateAffected updates all changesets which may be affected
-	// by a new commit to a repository and returns the list of update
+	// by new commits to a branch and returns the list of update
 	// events for all affected changesets.
 	UpdateAffected(ctx context.Context, in *ChangesetUpdateAffectedOp, opts ...grpc.CallOption) (*ChangesetEventList, error)
 	// CreateReview creates a new Review and returns it, populating
@@ -4819,7 +4819,7 @@ type ChangesetsServer interface {
 	// If no merge occurred, it returns nil.
 	Merge(context.Context, *ChangesetMergeOp) (*ChangesetEvent, error)
 	// UpdateAffected updates all changesets which may be affected
-	// by a new commit to a repository and returns the list of update
+	// by new commits to a branch and returns the list of update
 	// events for all affected changesets.
 	UpdateAffected(context.Context, *ChangesetUpdateAffectedOp) (*ChangesetEventList, error)
 	// CreateReview creates a new Review and returns it, populating

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -63,6 +63,7 @@ It has these top-level messages:
 	ChangesetSpec
 	ChangesetUpdateOp
 	ChangesetMergeOp
+	ChangesetUpdateAffectedOp
 	DiscussionSpec
 	DiscussionListOp
 	DiscussionCommentCreateOp
@@ -1217,6 +1218,21 @@ type ChangesetMergeOp struct {
 func (m *ChangesetMergeOp) Reset()         { *m = ChangesetMergeOp{} }
 func (m *ChangesetMergeOp) String() string { return proto.CompactTextString(m) }
 func (*ChangesetMergeOp) ProtoMessage()    {}
+
+type ChangesetUpdateAffectedOp struct {
+	// Repo holds the RepoSpec which received a commit.
+	Repo RepoSpec `protobuf:"bytes,1,opt,name=repo" json:"repo"`
+	// Branch is the name of the branch which was pushed to.
+	Branch string `protobuf:"bytes,2,opt,name=branch,proto3" json:"branch,omitempty"`
+	// Last is the SHA1 of the previous commit on the branch.
+	Last string `protobuf:"bytes,3,opt,name=last,proto3" json:"last,omitempty"`
+	// Commit is the SHA1 of the newly pushed commit on the branch.
+	Commit string `protobuf:"bytes,4,opt,name=commit,proto3" json:"commit,omitempty"`
+}
+
+func (m *ChangesetUpdateAffectedOp) Reset()         { *m = ChangesetUpdateAffectedOp{} }
+func (m *ChangesetUpdateAffectedOp) String() string { return proto.CompactTextString(m) }
+func (*ChangesetUpdateAffectedOp) ProtoMessage()    {}
 
 type DiscussionSpec struct {
 	Repo RepoSpec `protobuf:"bytes,1,opt,name=repo" json:"repo"`
@@ -4676,13 +4692,17 @@ type ChangesetsClient interface {
 	Get(ctx context.Context, in *ChangesetSpec, opts ...grpc.CallOption) (*Changeset, error)
 	// List lists changesets for a repository.
 	List(ctx context.Context, in *ChangesetListOp, opts ...grpc.CallOption) (*ChangesetList, error)
-	// UpdateChangeset updates a changeset's fields and returns the
+	// Update updates a changeset's fields and returns the
 	// update event. If no update occurred, it returns nil.
 	Update(ctx context.Context, in *ChangesetUpdateOp, opts ...grpc.CallOption) (*ChangesetEvent, error)
 	// Merge merges the head branch of a changeset into its base branch and
 	// pushes the resulting merged base. It returns the resulting update event.
 	// If no merge occurred, it returns nil.
 	Merge(ctx context.Context, in *ChangesetMergeOp, opts ...grpc.CallOption) (*ChangesetEvent, error)
+	// UpdateAffected updates all changesets which may be affected
+	// by a new commit to a repository and returns the list of update
+	// events for all affected changesets.
+	UpdateAffected(ctx context.Context, in *ChangesetUpdateAffectedOp, opts ...grpc.CallOption) (*ChangesetEventList, error)
 	// CreateReview creates a new Review and returns it, populating
 	// its fields, such as ID and CreatedAt.
 	CreateReview(ctx context.Context, in *ChangesetCreateReviewOp, opts ...grpc.CallOption) (*ChangesetReview, error)
@@ -4745,6 +4765,15 @@ func (c *changesetsClient) Merge(ctx context.Context, in *ChangesetMergeOp, opts
 	return out, nil
 }
 
+func (c *changesetsClient) UpdateAffected(ctx context.Context, in *ChangesetUpdateAffectedOp, opts ...grpc.CallOption) (*ChangesetEventList, error) {
+	out := new(ChangesetEventList)
+	err := grpc.Invoke(ctx, "/sourcegraph.Changesets/UpdateAffected", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *changesetsClient) CreateReview(ctx context.Context, in *ChangesetCreateReviewOp, opts ...grpc.CallOption) (*ChangesetReview, error) {
 	out := new(ChangesetReview)
 	err := grpc.Invoke(ctx, "/sourcegraph.Changesets/CreateReview", in, out, c.cc, opts...)
@@ -4782,13 +4811,17 @@ type ChangesetsServer interface {
 	Get(context.Context, *ChangesetSpec) (*Changeset, error)
 	// List lists changesets for a repository.
 	List(context.Context, *ChangesetListOp) (*ChangesetList, error)
-	// UpdateChangeset updates a changeset's fields and returns the
+	// Update updates a changeset's fields and returns the
 	// update event. If no update occurred, it returns nil.
 	Update(context.Context, *ChangesetUpdateOp) (*ChangesetEvent, error)
 	// Merge merges the head branch of a changeset into its base branch and
 	// pushes the resulting merged base. It returns the resulting update event.
 	// If no merge occurred, it returns nil.
 	Merge(context.Context, *ChangesetMergeOp) (*ChangesetEvent, error)
+	// UpdateAffected updates all changesets which may be affected
+	// by a new commit to a repository and returns the list of update
+	// events for all affected changesets.
+	UpdateAffected(context.Context, *ChangesetUpdateAffectedOp) (*ChangesetEventList, error)
 	// CreateReview creates a new Review and returns it, populating
 	// its fields, such as ID and CreatedAt.
 	CreateReview(context.Context, *ChangesetCreateReviewOp) (*ChangesetReview, error)
@@ -4862,6 +4895,18 @@ func _Changesets_Merge_Handler(srv interface{}, ctx context.Context, dec func(in
 	return out, nil
 }
 
+func _Changesets_UpdateAffected_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(ChangesetUpdateAffectedOp)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ChangesetsServer).UpdateAffected(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func _Changesets_CreateReview_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
 	in := new(ChangesetCreateReviewOp)
 	if err := dec(in); err != nil {
@@ -4921,6 +4966,10 @@ var _Changesets_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Merge",
 			Handler:    _Changesets_Merge_Handler,
+		},
+		{
+			MethodName: "UpdateAffected",
+			Handler:    _Changesets_UpdateAffected_Handler,
 		},
 		{
 			MethodName: "CreateReview",

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -814,7 +814,7 @@ service Changesets {
 	rpc Merge(ChangesetMergeOp) returns (ChangesetEvent);
 
 	// UpdateAffected updates all changesets which may be affected
-	// by a new commit to a repository and returns the list of update
+	// by new commits to a branch and returns the list of update
 	// events for all affected changesets.
 	rpc UpdateAffected(ChangesetUpdateAffectedOp) returns (ChangesetEventList);
 
@@ -1020,10 +1020,10 @@ message ChangesetUpdateAffectedOp {
 	// Branch is the name of the branch which was pushed to.
 	string branch = 2;
 
-	// Last is the SHA1 of the previous commit on the branch.
+	// Last is the SHA1 of the last commit on the branch.
 	string last = 3;
 
-	// Commit is the SHA1 of the newly pushed commit on the branch.
+	// Commit is the SHA1 of the tip of the newly pushed commits on the branch.
 	string commit = 4;
 }
 

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -804,7 +804,7 @@ service Changesets {
 	// List lists changesets for a repository.
 	rpc List(ChangesetListOp) returns (ChangesetList);
 
-	// UpdateChangeset updates a changeset's fields and returns the
+	// Update updates a changeset's fields and returns the
 	// update event. If no update occurred, it returns nil.
 	rpc Update(ChangesetUpdateOp) returns (ChangesetEvent);
 
@@ -812,6 +812,11 @@ service Changesets {
 	// pushes the resulting merged base. It returns the resulting update event.
 	// If no merge occurred, it returns nil.
 	rpc Merge(ChangesetMergeOp) returns (ChangesetEvent);
+
+	// UpdateAffected updates all changesets which may be affected
+	// by a new commit to a repository and returns the list of update
+	// events for all affected changesets.
+	rpc UpdateAffected(ChangesetUpdateAffectedOp) returns (ChangesetEventList);
 
 	// CreateReview creates a new Review and returns it, populating
 	// its fields, such as ID and CreatedAt.
@@ -1006,6 +1011,20 @@ message ChangesetMergeOp {
 	// Squash, if true, will squash the commits of the head branch into a
 	// single commit prior to merging.
 	bool squash = 4;
+}
+
+message ChangesetUpdateAffectedOp {
+	// Repo holds the RepoSpec which received a commit.
+	RepoSpec repo = 1 [(gogoproto.nullable) = false];
+
+	// Branch is the name of the branch which was pushed to.
+	string branch = 2;
+
+	// Last is the SHA1 of the previous commit on the branch.
+	string last = 3;
+
+	// Commit is the SHA1 of the newly pushed commit on the branch.
+	string commit = 4;
 }
 
 message DiscussionSpec {


### PR DESCRIPTION
The Changesets service will have an `UpdateAffected` method which updates all changesets that are affected by a new commit.

This makes implementing event-based updates for Changesets easy: listen for new commits and call Changesets.UpdateAffected with the commit information, and the service implementation can handle updating all affected changesets.