### PR TITLE
Add Auth.GetOwnPermissions endpoint.

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -211,6 +211,17 @@ func (s *CachedAuthServer) Identify(ctx context.Context, in *pbtypes.Void) (*Aut
 	return result, err
 }
 
+func (s *CachedAuthServer) GetOwnPermissions(ctx context.Context, in *pbtypes.Void) (*UserPermissions, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.AuthServer.GetOwnPermissions(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
 type CachedAuthClient struct {
 	AuthClient
 	Cache *grpccache.Cache
@@ -288,6 +299,32 @@ func (s *CachedAuthClient) Identify(ctx context.Context, in *pbtypes.Void, opts 
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "Auth.Identify", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedAuthClient) GetOwnPermissions(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*UserPermissions, error) {
+	if s.Cache != nil {
+		var cachedResult UserPermissions
+		cached, err := s.Cache.Get(ctx, "Auth.GetOwnPermissions", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.AuthClient.GetOwnPermissions(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Auth.GetOwnPermissions", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -845,6 +845,7 @@ type AuthClient struct {
 	GetAuthorizationCode_ func(ctx context.Context, in *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error)
 	GetAccessToken_       func(ctx context.Context, in *sourcegraph.AccessTokenRequest) (*sourcegraph.AccessTokenResponse, error)
 	Identify_             func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.AuthInfo, error)
+	GetOwnPermissions_    func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.UserPermissions, error)
 }
 
 func (s *AuthClient) GetAuthorizationCode(ctx context.Context, in *sourcegraph.AuthorizationCodeRequest, opts ...grpc.CallOption) (*sourcegraph.AuthorizationCode, error) {
@@ -859,12 +860,17 @@ func (s *AuthClient) Identify(ctx context.Context, in *pbtypes.Void, opts ...grp
 	return s.Identify_(ctx, in)
 }
 
+func (s *AuthClient) GetOwnPermissions(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*sourcegraph.UserPermissions, error) {
+	return s.GetOwnPermissions_(ctx, in)
+}
+
 var _ sourcegraph.AuthClient = (*AuthClient)(nil)
 
 type AuthServer struct {
 	GetAuthorizationCode_ func(v0 context.Context, v1 *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error)
 	GetAccessToken_       func(v0 context.Context, v1 *sourcegraph.AccessTokenRequest) (*sourcegraph.AccessTokenResponse, error)
 	Identify_             func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.AuthInfo, error)
+	GetOwnPermissions_    func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.UserPermissions, error)
 }
 
 func (s *AuthServer) GetAuthorizationCode(v0 context.Context, v1 *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error) {
@@ -877,6 +883,10 @@ func (s *AuthServer) GetAccessToken(v0 context.Context, v1 *sourcegraph.AccessTo
 
 func (s *AuthServer) Identify(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.AuthInfo, error) {
 	return s.Identify_(v0, v1)
+}
+
+func (s *AuthServer) GetOwnPermissions(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.UserPermissions, error) {
+	return s.GetOwnPermissions_(v0, v1)
 }
 
 var _ sourcegraph.AuthServer = (*AuthServer)(nil)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -6204,6 +6204,8 @@ type AuthClient interface {
 	// Identify describes the currently authenticated user and/or
 	// client (if any). It is akin to "whoami".
 	Identify(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*AuthInfo, error)
+	// GetOwnPermissions returns the permissions of the currently authenticated user.
+	GetOwnPermissions(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*UserPermissions, error)
 }
 
 type authClient struct {
@@ -6241,6 +6243,15 @@ func (c *authClient) Identify(ctx context.Context, in *pbtypes1.Void, opts ...gr
 	return out, nil
 }
 
+func (c *authClient) GetOwnPermissions(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*UserPermissions, error) {
+	out := new(UserPermissions)
+	err := grpc.Invoke(ctx, "/sourcegraph.Auth/GetOwnPermissions", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Auth service
 
 type AuthServer interface {
@@ -6266,6 +6277,8 @@ type AuthServer interface {
 	// Identify describes the currently authenticated user and/or
 	// client (if any). It is akin to "whoami".
 	Identify(context.Context, *pbtypes1.Void) (*AuthInfo, error)
+	// GetOwnPermissions returns the permissions of the currently authenticated user.
+	GetOwnPermissions(context.Context, *pbtypes1.Void) (*UserPermissions, error)
 }
 
 func RegisterAuthServer(s *grpc.Server, srv AuthServer) {
@@ -6308,6 +6321,18 @@ func _Auth_Identify_Handler(srv interface{}, ctx context.Context, dec func(inter
 	return out, nil
 }
 
+func _Auth_GetOwnPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(pbtypes1.Void)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(AuthServer).GetOwnPermissions(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _Auth_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sourcegraph.Auth",
 	HandlerType: (*AuthServer)(nil),
@@ -6323,6 +6348,10 @@ var _Auth_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Identify",
 			Handler:    _Auth_Identify_Handler,
+		},
+		{
+			MethodName: "GetOwnPermissions",
+			Handler:    _Auth_GetOwnPermissions_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1835,6 +1835,13 @@ service Auth {
 			get: "/auth/identify"
 		};
 	};
+
+	// GetOwnPermissions returns the permissions of the currently authenticated user.
+	rpc GetOwnPermissions(pbtypes.Void) returns (UserPermissions) {
+		option (google.api.http) = {
+			get: "/auth/get_own_permissions"
+		};
+	};
 }
 
 // SSHPublicKey that users to authenticate with for SSH git access.


### PR DESCRIPTION
The motivation is for platform apps to be able to access the permissions of the current user, and perform authorization checks themselves based on that information.

/cc @pararthshah
