### PR TITLE
Misc. changes for user auth

### DIFF
--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -855,6 +855,7 @@ type AuthClient struct {
 	GetAuthorizationCode_ func(ctx context.Context, in *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error)
 	GetAccessToken_       func(ctx context.Context, in *sourcegraph.AccessTokenRequest) (*sourcegraph.AccessTokenResponse, error)
 	Identify_             func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.AuthInfo, error)
+	GetPermissions_       func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.UserPermissions, error)
 }
 
 func (s *AuthClient) GetAuthorizationCode(ctx context.Context, in *sourcegraph.AuthorizationCodeRequest, opts ...grpc.CallOption) (*sourcegraph.AuthorizationCode, error) {
@@ -869,12 +870,17 @@ func (s *AuthClient) Identify(ctx context.Context, in *pbtypes.Void, opts ...grp
 	return s.Identify_(ctx, in)
 }
 
+func (s *AuthClient) GetPermissions(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*sourcegraph.UserPermissions, error) {
+	return s.GetPermissions_(ctx, in)
+}
+
 var _ sourcegraph.AuthClient = (*AuthClient)(nil)
 
 type AuthServer struct {
 	GetAuthorizationCode_ func(v0 context.Context, v1 *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error)
 	GetAccessToken_       func(v0 context.Context, v1 *sourcegraph.AccessTokenRequest) (*sourcegraph.AccessTokenResponse, error)
 	Identify_             func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.AuthInfo, error)
+	GetPermissions_       func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.UserPermissions, error)
 }
 
 func (s *AuthServer) GetAuthorizationCode(v0 context.Context, v1 *sourcegraph.AuthorizationCodeRequest) (*sourcegraph.AuthorizationCode, error) {
@@ -887,6 +893,10 @@ func (s *AuthServer) GetAccessToken(v0 context.Context, v1 *sourcegraph.AccessTo
 
 func (s *AuthServer) Identify(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.AuthInfo, error) {
 	return s.Identify_(v0, v1)
+}
+
+func (s *AuthServer) GetPermissions(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.UserPermissions, error) {
+	return s.GetPermissions_(v0, v1)
 }
 
 var _ sourcegraph.AuthServer = (*AuthServer)(nil)

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -762,13 +762,18 @@ func (s *AccountsServer) Update(v0 context.Context, v1 *sourcegraph.User) (*pbty
 var _ sourcegraph.AccountsServer = (*AccountsServer)(nil)
 
 type UsersClient struct {
-	Get_        func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_ func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_       func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	Get_          func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	GetWithEmail_ func(ctx context.Context, in *sourcegraph.EmailAddr) (*sourcegraph.User, error)
+	ListEmails_   func(ctx context.Context, in *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_         func(ctx context.Context, in *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
 }
 
 func (s *UsersClient) Get(ctx context.Context, in *sourcegraph.UserSpec, opts ...grpc.CallOption) (*sourcegraph.User, error) {
 	return s.Get_(ctx, in)
+}
+
+func (s *UsersClient) GetWithEmail(ctx context.Context, in *sourcegraph.EmailAddr, opts ...grpc.CallOption) (*sourcegraph.User, error) {
+	return s.GetWithEmail_(ctx, in)
 }
 
 func (s *UsersClient) ListEmails(ctx context.Context, in *sourcegraph.UserSpec, opts ...grpc.CallOption) (*sourcegraph.EmailAddrList, error) {
@@ -782,13 +787,18 @@ func (s *UsersClient) List(ctx context.Context, in *sourcegraph.UsersListOptions
 var _ sourcegraph.UsersClient = (*UsersClient)(nil)
 
 type UsersServer struct {
-	Get_        func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
-	ListEmails_ func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
-	List_       func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
+	Get_          func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error)
+	GetWithEmail_ func(v0 context.Context, v1 *sourcegraph.EmailAddr) (*sourcegraph.User, error)
+	ListEmails_   func(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error)
+	List_         func(v0 context.Context, v1 *sourcegraph.UsersListOptions) (*sourcegraph.UserList, error)
 }
 
 func (s *UsersServer) Get(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.User, error) {
 	return s.Get_(v0, v1)
+}
+
+func (s *UsersServer) GetWithEmail(v0 context.Context, v1 *sourcegraph.EmailAddr) (*sourcegraph.User, error) {
+	return s.GetWithEmail_(v0, v1)
 }
 
 func (s *UsersServer) ListEmails(v0 context.Context, v1 *sourcegraph.UserSpec) (*sourcegraph.EmailAddrList, error) {

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -1941,6 +1941,8 @@ type NewAccount struct {
 	Email string `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
 	// Password is the password for the new user account.
 	Password string `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
+	// UID is the desired UID for the new user account.
+	UID int32 `protobuf:"varint,4,opt,name=uid,proto3" json:"uid,omitempty"`
 }
 
 func (m *NewAccount) Reset()         { *m = NewAccount{} }

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -3530,6 +3530,9 @@ type ServerConfig struct {
 	// users may perform "read" operations, such as viewing
 	// repositories.
 	AllowAnonymousReaders bool `protobuf:"varint,9,opt,name=allow_anonymous_readers,proto3" json:"allow_anonymous_readers,omitempty"`
+	// AuthSource is which mode of authentication is set up on the
+	// server (local|oauth|ldap).
+	AuthSource string `protobuf:"bytes,10,opt,name=auth_source,proto3" json:"auth_source,omitempty"`
 }
 
 func (m *ServerConfig) Reset()         { *m = ServerConfig{} }

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -6279,6 +6279,9 @@ type AuthClient interface {
 	// Identify describes the currently authenticated user and/or
 	// client (if any). It is akin to "whoami".
 	Identify(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*AuthInfo, error)
+	// GetPermissions returns the currently authenticated user's
+	// authorization levels on the client.
+	GetPermissions(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*UserPermissions, error)
 }
 
 type authClient struct {
@@ -6316,6 +6319,15 @@ func (c *authClient) Identify(ctx context.Context, in *pbtypes1.Void, opts ...gr
 	return out, nil
 }
 
+func (c *authClient) GetPermissions(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*UserPermissions, error) {
+	out := new(UserPermissions)
+	err := grpc.Invoke(ctx, "/sourcegraph.Auth/GetPermissions", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Auth service
 
 type AuthServer interface {
@@ -6341,6 +6353,9 @@ type AuthServer interface {
 	// Identify describes the currently authenticated user and/or
 	// client (if any). It is akin to "whoami".
 	Identify(context.Context, *pbtypes1.Void) (*AuthInfo, error)
+	// GetPermissions returns the currently authenticated user's
+	// authorization levels on the client.
+	GetPermissions(context.Context, *pbtypes1.Void) (*UserPermissions, error)
 }
 
 func RegisterAuthServer(s *grpc.Server, srv AuthServer) {
@@ -6383,6 +6398,18 @@ func _Auth_Identify_Handler(srv interface{}, ctx context.Context, dec func(inter
 	return out, nil
 }
 
+func _Auth_GetPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(pbtypes1.Void)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(AuthServer).GetPermissions(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _Auth_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sourcegraph.Auth",
 	HandlerType: (*AuthServer)(nil),
@@ -6398,6 +6425,10 @@ var _Auth_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Identify",
 			Handler:    _Auth_Identify_Handler,
+		},
+		{
+			MethodName: "GetPermissions",
+			Handler:    _Auth_GetPermissions_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -5994,6 +5994,8 @@ var _Accounts_serviceDesc = grpc.ServiceDesc{
 type UsersClient interface {
 	// Get fetches a user.
 	Get(ctx context.Context, in *UserSpec, opts ...grpc.CallOption) (*User, error)
+	// GetWithEmail fetches a user by their primary email.
+	GetWithEmail(ctx context.Context, in *EmailAddr, opts ...grpc.CallOption) (*User, error)
 	// ListEmails returns a list of a user's email addresses.
 	ListEmails(ctx context.Context, in *UserSpec, opts ...grpc.CallOption) (*EmailAddrList, error)
 	// List users.
@@ -6011,6 +6013,15 @@ func NewUsersClient(cc *grpc.ClientConn) UsersClient {
 func (c *usersClient) Get(ctx context.Context, in *UserSpec, opts ...grpc.CallOption) (*User, error) {
 	out := new(User)
 	err := grpc.Invoke(ctx, "/sourcegraph.Users/Get", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *usersClient) GetWithEmail(ctx context.Context, in *EmailAddr, opts ...grpc.CallOption) (*User, error) {
+	out := new(User)
+	err := grpc.Invoke(ctx, "/sourcegraph.Users/GetWithEmail", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -6040,6 +6051,8 @@ func (c *usersClient) List(ctx context.Context, in *UsersListOptions, opts ...gr
 type UsersServer interface {
 	// Get fetches a user.
 	Get(context.Context, *UserSpec) (*User, error)
+	// GetWithEmail fetches a user by their primary email.
+	GetWithEmail(context.Context, *EmailAddr) (*User, error)
 	// ListEmails returns a list of a user's email addresses.
 	ListEmails(context.Context, *UserSpec) (*EmailAddrList, error)
 	// List users.
@@ -6056,6 +6069,18 @@ func _Users_Get_Handler(srv interface{}, ctx context.Context, dec func(interface
 		return nil, err
 	}
 	out, err := srv.(UsersServer).Get(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Users_GetWithEmail_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(EmailAddr)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(UsersServer).GetWithEmail(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -6093,6 +6118,10 @@ var _Users_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Get",
 			Handler:    _Users_Get_Handler,
+		},
+		{
+			MethodName: "GetWithEmail",
+			Handler:    _Users_GetWithEmail_Handler,
 		},
 		{
 			MethodName: "ListEmails",

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1845,6 +1845,14 @@ service Auth {
 			get: "/auth/identify"
 		};
 	};
+
+	// GetPermissions returns the currently authenticated user's
+	// authorization levels on the client.
+	rpc GetPermissions(pbtypes.Void) returns (UserPermissions) {
+		option (google.api.http) = {
+			get: "/auth/verify"
+		};
+	};
 }
 
 // SSHPublicKey that users to authenticate with for SSH git access.

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1778,6 +1778,13 @@ service Users {
 		};
 	};
 
+	// GetWithEmail fetches a user by their primary email.
+	rpc GetWithEmail(EmailAddr) returns (User) {
+		option (google.api.http) = {
+			get: "/users/by_email"
+		};
+	};
+
 	// ListEmails returns a list of a user's email addresses.
 	rpc ListEmails(UserSpec) returns (EmailAddrList) {
 		option (google.api.http) = {

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -1766,6 +1766,9 @@ message NewAccount {
 
 	// Password is the password for the new user account.
 	string password = 3;
+
+	// UID is the desired UID for the new user account.
+	int32 uid = 4 [(gogoproto.customname) = "UID"];
 }
 
 // UsersService communicates with the users-related endpoints in the Sourcegraph

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -3043,6 +3043,10 @@ message ServerConfig {
 	// users may perform "read" operations, such as viewing
 	// repositories.
 	bool allow_anonymous_readers = 9;
+
+	// AuthSource is which mode of authentication is set up on the
+	// server (local|oauth|ldap).
+	string auth_source = 10;
 }
 
 // A RegisteredClient is a registered API client.


### PR DESCRIPTION
This PR contains multiple changes geared towards supporting LDAP integration:

1. Users.GetWithEmail: fetch a user with their primary email

2. Add UID field to sourcegraph.NewAccount: this will allow local instances with LDAP auth to link their local user records with sourcegraph.com user accounts.

3. Auth.GetPermissions: returns permissions of the current user. /cc @shurcooL this will be useful to you.

4. ServerConfig will return AuthSource, for gRPC clients to find out what is the configured auth mode on the server (local, oauth or ldap).