### PR TITLE
Fix Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: go
 
 go:
-  - 1.4
+  - 1.5
   - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 
 before_install:
   - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph
@@ -10,4 +15,7 @@ before_install:
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/sourcegraph.com/sourcegraph/go-sourcegraph
 
 install:
-  - go get -t -d -v ./... && go build -v ./...
+  - go get -t -d -v ./...
+
+script:
+  - go build -v ./...


### PR DESCRIPTION
- Use Go 1.5.

- Make tip allowed failure with fast finish.

- Move build step into script; keep downloading dependencies as an install step.
    - This means if a dependency fails to be installed, the build will be classified as an build error. But if building the library itself fails, that's classified as a build failure.
    - Find more information at http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/.