### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,3 @@ If you run into errors while compiling protobufs, try again with these versions 
    ```
    go generate ./...
    ```
-
-   You can ignore warnings about "No syntax specified for the proto file." These are caused by old protobuf definition files that don't explicitly specify the new proto3 syntax, but they are harmless.


### PR DESCRIPTION
This is a followup to #77. After updating to latest versions of protobuf generators and resolving protobuf definition file issues, there are no more warnings emitted. They can now be removed from the README.

/cc @pararthshah