### PR TITLE
sourcegraph: fix data race in GetRequestMetadata

### DIFF
--- a/sourcegraph/context.go
+++ b/sourcegraph/context.go
@@ -136,8 +136,11 @@ var RemovePooledGRPCConn = func(ctx context.Context) {
 	removeConnFromPool(grpcEndpoint.Host)
 }
 
+// contextCredentials implements the credentials.Credentials interface.
 type contextCredentials struct{}
 
+// GetRequestMetadata implements the credentials.Credentials interface. As per the
+// interface definition, it may be called by multiple goroutines concurrently.
 func (contextCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
 	m := clientMetadataFromContext(ctx)
 
@@ -150,6 +153,8 @@ func (contextCredentials) GetRequestMetadata(ctx context.Context, uri ...string)
 		if m == nil {
 			m = credMD
 		} else {
+			// Copy the map to avoid a data race writing to the map returned by
+			// clientMetaDataFromContext.
 			cpy := make(map[string]string)
 			for k, v := range m {
 				cpy[k] = v
@@ -163,6 +168,7 @@ func (contextCredentials) GetRequestMetadata(ctx context.Context, uri ...string)
 	return m, nil
 }
 
+// RequireTransportSecurity implements the credentials.Credentials interface.
 func (contextCredentials) RequireTransportSecurity() bool {
 	return false
 }

--- a/sourcegraph/context.go
+++ b/sourcegraph/context.go
@@ -150,9 +150,14 @@ func (contextCredentials) GetRequestMetadata(ctx context.Context, uri ...string)
 		if m == nil {
 			m = credMD
 		} else {
-			for k, v := range credMD {
-				m[k] = v
+			cpy := make(map[string]string)
+			for k, v := range m {
+				cpy[k] = v
 			}
+			for k, v := range credMD {
+				cpy[k] = v
+			}
+			m = cpy
 		}
 	}
 	return m, nil


### PR DESCRIPTION
`GetRequestMetadata` can be called by multiple goroutines concurrently. The docs on [credentials.Credentials.GetRequestMetadata](https://godoc.org/google.golang.org/grpc/credentials#Credentials) read:

```
// GetRequestMetadata gets the current request metadata, refreshing
// tokens if required. This should be called by the transport layer on
// each request, and the data should be populated in headers or other
// context. uri is the URI of the entry point for the request. When
// supported by the underlying implementation, ctx can be used for
// timeout and cancellation.
```

Emphasis on _"This should be called by the transport layer on each request"_.
