### PR TITLE
sourcegraph: add override fields to NotifyGenericEvent

### DIFF
--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -3740,6 +3740,14 @@ type NotifyGenericEvent struct {
 	ObjectTitle string `protobuf:"bytes,8,opt,name=object_title,proto3" json:"object_title,omitempty"`
 	// ObjectURL example: "https://src.sourcegraph.com/sourcegraph/.changesets/71"
 	ObjectURL string `protobuf:"bytes,9,opt,name=object_url,proto3" json:"object_url,omitempty"`
+	// SlackMsg, if present, will override the Slack message for this event.
+	SlackMsg string `protobuf:"bytes,10,opt,name=slack_msg,proto3" json:"slack_msg,omitempty"`
+	// EmailHTML, if present, will override the notification email body for this event.
+	EmailHTML string `protobuf:"bytes,11,opt,name=email_html,proto3" json:"email_html,omitempty"`
+	// NoSlack turns off the Slack notification for this event.
+	NoSlack bool `protobuf:"varint,12,opt,name=no_slack,proto3" json:"no_slack,omitempty"`
+	// NoEmail turns off the email notification for this event.
+	NoEmail bool `protobuf:"varint,13,opt,name=no_email,proto3" json:"no_email,omitempty"`
 }
 
 func (m *NotifyGenericEvent) Reset()         { *m = NotifyGenericEvent{} }

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -3321,6 +3321,18 @@ message NotifyGenericEvent {
 
 	// ObjectURL example: "https://src.sourcegraph.com/sourcegraph/.changesets/71"
 	string object_url = 9 [(gogoproto.customname) = "ObjectURL"];
+
+	// SlackMsg, if present, will override the Slack message for this event.
+	string slack_msg = 10;
+
+	// EmailHTML, if present, will override the notification email body for this event.
+	string email_html = 11 [(gogoproto.customname) = "EmailHTML"];
+
+	// NoSlack turns off the Slack notification for this event.
+	bool no_slack = 12;
+
+	// NoEmail turns off the email notification for this event.
+	bool no_email = 13;
 }
 
 // Notify service


### PR DESCRIPTION
This PR adds fields to NotifyGenericEvent that will override:

- the default Slack message template
- the default email body template
- sending a Slack notification for this event
- sending an email notification for this event