### PR TITLE
sourcegraph: added Meta.PubKey endpoint to fetch the server's public key

### DIFF
--- a/sourcegraph/cached_grpc.pb.go
+++ b/sourcegraph/cached_grpc.pb.go
@@ -1884,6 +1884,17 @@ func (s *CachedMetaServer) Config(ctx context.Context, in *pbtypes.Void) (*Serve
 	return result, err
 }
 
+func (s *CachedMetaServer) PubKey(ctx context.Context, in *pbtypes.Void) (*ServerPubKey, error) {
+	ctx, cc := grpccache.Internal_WithCacheControl(ctx)
+	result, err := s.MetaServer.PubKey(ctx, in)
+	if !cc.IsZero() {
+		if err := grpccache.Internal_SetCacheControlTrailer(ctx, *cc); err != nil {
+			return nil, err
+		}
+	}
+	return result, err
+}
+
 type CachedMetaClient struct {
 	MetaClient
 	Cache *grpccache.Cache
@@ -1935,6 +1946,32 @@ func (s *CachedMetaClient) Config(ctx context.Context, in *pbtypes.Void, opts ..
 	}
 	if s.Cache != nil {
 		if err := s.Cache.Store(ctx, "Meta.Config", in, result, trailer); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *CachedMetaClient) PubKey(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*ServerPubKey, error) {
+	if s.Cache != nil {
+		var cachedResult ServerPubKey
+		cached, err := s.Cache.Get(ctx, "Meta.PubKey", in, &cachedResult)
+		if err != nil {
+			return nil, err
+		}
+		if cached {
+			return &cachedResult, nil
+		}
+	}
+
+	var trailer metadata.MD
+
+	result, err := s.MetaClient.PubKey(ctx, in, grpc.Trailer(&trailer))
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		if err := s.Cache.Store(ctx, "Meta.PubKey", in, result, trailer); err != nil {
 			return nil, err
 		}
 	}

--- a/sourcegraph/mock/sourcegraph.pb_mock.go
+++ b/sourcegraph/mock/sourcegraph.pb_mock.go
@@ -1204,6 +1204,7 @@ var _ sourcegraph.UnitsServer = (*UnitsServer)(nil)
 type MetaClient struct {
 	Status_ func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.ServerStatus, error)
 	Config_ func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.ServerConfig, error)
+	PubKey_ func(ctx context.Context, in *pbtypes.Void) (*sourcegraph.ServerPubKey, error)
 }
 
 func (s *MetaClient) Status(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*sourcegraph.ServerStatus, error) {
@@ -1214,11 +1215,16 @@ func (s *MetaClient) Config(ctx context.Context, in *pbtypes.Void, opts ...grpc.
 	return s.Config_(ctx, in)
 }
 
+func (s *MetaClient) PubKey(ctx context.Context, in *pbtypes.Void, opts ...grpc.CallOption) (*sourcegraph.ServerPubKey, error) {
+	return s.PubKey_(ctx, in)
+}
+
 var _ sourcegraph.MetaClient = (*MetaClient)(nil)
 
 type MetaServer struct {
 	Status_ func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerStatus, error)
 	Config_ func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerConfig, error)
+	PubKey_ func(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerPubKey, error)
 }
 
 func (s *MetaServer) Status(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerStatus, error) {
@@ -1227,6 +1233,10 @@ func (s *MetaServer) Status(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.
 
 func (s *MetaServer) Config(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerConfig, error) {
 	return s.Config_(v0, v1)
+}
+
+func (s *MetaServer) PubKey(v0 context.Context, v1 *pbtypes.Void) (*sourcegraph.ServerPubKey, error) {
+	return s.PubKey_(v0, v1)
 }
 
 var _ sourcegraph.MetaServer = (*MetaServer)(nil)

--- a/sourcegraph/sourcegraph.pb.go
+++ b/sourcegraph/sourcegraph.pb.go
@@ -216,6 +216,7 @@ It has these top-level messages:
 	PBToken
 	ServerStatus
 	ServerConfig
+	ServerPubKey
 	RegisteredClient
 	RegisteredClientSpec
 	RegisteredClientCredentials
@@ -3553,6 +3554,16 @@ type ServerConfig struct {
 func (m *ServerConfig) Reset()         { *m = ServerConfig{} }
 func (m *ServerConfig) String() string { return proto.CompactTextString(m) }
 func (*ServerConfig) ProtoMessage()    {}
+
+// ServerPubKey holds the server's public key.
+type ServerPubKey struct {
+	// Key contains the server's published public key.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+}
+
+func (m *ServerPubKey) Reset()         { *m = ServerPubKey{} }
+func (m *ServerPubKey) String() string { return proto.CompactTextString(m) }
+func (*ServerPubKey) ProtoMessage()    {}
 
 // A RegisteredClient is a registered API client.
 //
@@ -7339,6 +7350,8 @@ type MetaClient interface {
 	Status(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*ServerStatus, error)
 	// Config returns the server's configuration.
 	Config(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*ServerConfig, error)
+	// PubKey returns the server's public key.
+	PubKey(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*ServerPubKey, error)
 }
 
 type metaClient struct {
@@ -7367,6 +7380,15 @@ func (c *metaClient) Config(ctx context.Context, in *pbtypes1.Void, opts ...grpc
 	return out, nil
 }
 
+func (c *metaClient) PubKey(ctx context.Context, in *pbtypes1.Void, opts ...grpc.CallOption) (*ServerPubKey, error) {
+	out := new(ServerPubKey)
+	err := grpc.Invoke(ctx, "/sourcegraph.Meta/PubKey", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Meta service
 
 type MetaServer interface {
@@ -7375,6 +7397,8 @@ type MetaServer interface {
 	Status(context.Context, *pbtypes1.Void) (*ServerStatus, error)
 	// Config returns the server's configuration.
 	Config(context.Context, *pbtypes1.Void) (*ServerConfig, error)
+	// PubKey returns the server's public key.
+	PubKey(context.Context, *pbtypes1.Void) (*ServerPubKey, error)
 }
 
 func RegisterMetaServer(s *grpc.Server, srv MetaServer) {
@@ -7405,6 +7429,18 @@ func _Meta_Config_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return out, nil
 }
 
+func _Meta_PubKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(pbtypes1.Void)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(MetaServer).PubKey(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _Meta_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sourcegraph.Meta",
 	HandlerType: (*MetaServer)(nil),
@@ -7416,6 +7452,10 @@ var _Meta_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Config",
 			Handler:    _Meta_Config_Handler,
+		},
+		{
+			MethodName: "PubKey",
+			Handler:    _Meta_PubKey_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/sourcegraph/sourcegraph.proto
+++ b/sourcegraph/sourcegraph.proto
@@ -3013,6 +3013,13 @@ service Meta {
 			get: "/meta/config"
 		};
 	};
+
+	// PubKey returns the server's public key.
+	rpc PubKey(pbtypes.Void) returns (ServerPubKey) {
+		option (google.api.http) = {
+			get: "/meta/pub_key"
+		};
+	};
 }
 
 // ServerStatus describes the server's status.
@@ -3067,6 +3074,12 @@ message ServerConfig {
 	// AuthSource is which mode of authentication is set up on the
 	// server (local|oauth|ldap).
 	string auth_source = 10;
+}
+
+// ServerPubKey holds the server's public key.
+message ServerPubKey {
+	// Key contains the server's published public key.
+	string key = 1;
 }
 
 // A RegisteredClient is a registered API client.


### PR DESCRIPTION
This will be used by clients to fetch the public key of the federation root in order to verify root-signed auth tokens locally.